### PR TITLE
RTL Fixes - RecordInParts Dialog

### DIFF
--- a/src/HearThis/HearThis.csproj
+++ b/src/HearThis/HearThis.csproj
@@ -73,10 +73,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\DesktopAnalytics.1.1.2\lib\net40\DesktopAnalytics.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=0.85.4.369, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\dotnet\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="Ionic.Zip, Version=1.9.1.8, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\dotnet\Ionic.Zip.dll</HintPath>

--- a/src/HearThis/UI/RecordInPartsDlg.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.cs
@@ -22,7 +22,6 @@ namespace HearThis.UI
 		Timer _waitToJoinTimer = new Timer();
 		private Color _scriptSecondHalfColor = AppPallette.SecondPartTextColor;
 		private AudioButtonsControl _audioButtonCurrent;
-		private bool _playedSecondOnce;
 
 		public RecordInPartsDlg()
 		{
@@ -244,10 +243,16 @@ namespace HearThis.UI
 			_waitToJoinTimer.Start();
 		}
 
-		public Font Font
+		public Font TextBoxFont
 		{
 			get { return _recordTextBox.Font; }
 			set { _recordTextBox.Font = value; }
+		}
+
+		public RightToLeft TextBoxRightToLeft
+		{
+			get { return _recordTextBox.RightToLeft; }
+			set { _recordTextBox.RightToLeft = value; }
 		}
 
 		/// <summary>

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -880,10 +880,11 @@ namespace HearThis.UI
 			{
 				var scriptLine = _project.GetBlock(_project.CurrentBookName, _project.SelectedChapterInfo.ChapterNumber1Based,
 					_project.SelectedScriptBlock);
+				dlg.TextBoxRightToLeft = scriptLine.RightToLeft ? RightToLeft.Yes : RightToLeft.No;
 				dlg.TextToRecord = scriptLine.Text;
 				dlg.RecordingDevice = _audioButtonsControl.RecordingDevice;
 				dlg.ContextForAnalytics = _audioButtonsControl.ContextForAnalytics;
-				dlg.Font = new Font(scriptLine.FontName, scriptLine.FontSize * _scriptControl.ZoomFactor);
+				dlg.TextBoxFont = new Font(scriptLine.FontName, scriptLine.FontSize * _scriptControl.ZoomFactor);
 				if (dlg.ShowDialog(this) == DialogResult.OK)
 				{
 					dlg.WriteCombinedAudio(_project.GetPathToRecordingForSelectedLine());


### PR DESCRIPTION
Fix RTL for line splitting dialog. Remove ICSharp as it is no longer used (replaced by Ionic.ZIP).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/2)
<!-- Reviewable:end -->
