### PR TITLE
Update installer and use Newtonsoft.Json 7.0.1 rather than 8.0.3 (HT-160)

### DIFF
--- a/DistFiles/localization/.guidsForInstaller.xml
+++ b/DistFiles/localization/.guidsForInstaller.xml
@@ -1,5 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--This file is generated and then updated by an MSBuild task.  It preserves the automatically-generated guids assigned files that will be installed on user machines. So it should be held in source control.-->
 <InstallerMetadata>
   <File Id="ProgramDir.localization.LocalizationsGoHere.txt" Guid="32b7a3f4-9a34-44b5-afa1-a6368511294b" />
+  <File Id="ProgramDir.localization.HearThis.es.tmx" Guid="478d2dd3-5aea-4762-82f4-c7ad46a94b26" />
+  <File Id="ProgramDir.localization.Palaso.es.tmx" Guid="8122b8bc-2760-4d58-b543-632215b97025" />
 </InstallerMetadata>

--- a/src/HearThis/HearThis.csproj
+++ b/src/HearThis/HearThis.csproj
@@ -105,8 +105,8 @@
     <Reference Include="NetSparkle.Net40">
       <HintPath>..\..\lib\dotnet\NetSparkle.Net40.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ParatextShared, Version=7.3.0.0, Culture=neutral, processorArchitecture=x86">

--- a/src/HearThis/app.config
+++ b/src/HearThis/app.config
@@ -80,7 +80,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/HearThis/packages.config
+++ b/src/HearThis/packages.config
@@ -3,6 +3,6 @@
   <package id="Analytics" version="2.0.0" targetFramework="net40-Client" />
   <package id="DesktopAnalytics" version="1.1.2" targetFramework="net40-Client" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net4-client" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net40-Client" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40-Client" />
   <package id="ZXing.Net" version="0.14.0.1" targetFramework="net40-Client" />
 </packages>

--- a/src/HearThisTests/HearThisTests.csproj
+++ b/src/HearThisTests/HearThisTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -75,8 +75,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\dotnet\L10NSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\lib\nunit.framework.dll</HintPath>

--- a/src/HearThisTests/app.config
+++ b/src/HearThisTests/app.config
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/HearThisTests/packages.config
+++ b/src/HearThisTests/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net40-Client" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40-Client" />
 </packages>

--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -229,6 +229,22 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 		  <Component Id="MarkdownDeep.dll" Guid="{92a3ad97-2988-4631-802d-1b1f8f10ecc7}">
 			<File Id="MarkdownDeep.dll" Name="MarkdownDeep.dll" KeyPath="yes" Source="..\..\output\release\MarkdownDeep.dll" />
 		  </Component>
+
+		  <Component Id="icu.net.dll" Guid="{a145070d-4fae-49ab-a7f5-4980895f62ba}">
+			<File Id="icu.net.dll" Name="icu.net.dll" KeyPath="yes" Source="..\..\output\release\icu.net.dll" />
+		  </Component>
+
+		  <Component Id="icudt54.dll" Guid="{73ee4690-c094-4aee-9ac2-b90ea1657887}">
+			<File Id="icudt54.dll" Name="icudt54.dll" KeyPath="yes" Source="..\..\output\release\icudt54.dll" />
+		  </Component>
+
+		  <Component Id="icuin54.dll" Guid="{fa40a15c-a057-4436-9f8c-a15bc154d36e}">
+			<File Id="icuin54.dll" Name="icuin54.dll" KeyPath="yes" Source="..\..\output\release\icuin54.dll" />
+		  </Component>
+
+		  <Component Id="icuuc54.dll" Guid="{7c312256-e864-40d6-bbcb-2f5b02d44557}">
+			<File Id="icuuc54.dll" Name="icuuc54.dll" KeyPath="yes" Source="..\..\output\release\icuuc54.dll" />
+		  </Component>
 		</Directory>
 	  </Directory>
 
@@ -288,6 +304,10 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 	  <ComponentRef Id="DesktopAnalytics.dll" />
 	  <ComponentRef Id="Newtonsoft.Json.dll"/>
 	  <ComponentRef Id="CreateProgramDataFolder"/>
+	  <ComponentRef Id="icu.net.dll"/>
+	  <ComponentRef Id="icudt54.dll"/>
+	  <ComponentRef Id="icuin54.dll"/>
+	  <ComponentRef Id="icuuc54.dll"/>
 	  <ComponentGroupRef Id ="DistFiles"/>
 
 	</Feature>


### PR DESCRIPTION
7.0.1 is the version SIL.WritingSystems is looking for, therefore 8.0.3 was causing a crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/4)
<!-- Reviewable:end -->
