### PR TITLE
Work around and gather info on HT-9

### DIFF
--- a/src/HearThis/HearThis.csproj
+++ b/src/HearThis/HearThis.csproj
@@ -27,7 +27,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>3</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -288,6 +288,13 @@
     <EmbeddedResource Include="UI\AndroidSyncDialog.resx">
       <DependentUpon>AndroidSyncDialog.cs</DependentUpon>
     </EmbeddedResource>
+    <Compile Include="UI\ToastNotifier.designer.cs" >
+      <DependentUpon>ToastNotifier.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Utils\NonFatalProblem.cs" />
+    <Compile Include="UI\ToastNotifier.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Utils\Utils.cs" />
     <EmbeddedResource Include="UI\BookButton.resx">
       <DependentUpon>BookButton.cs</DependentUpon>
@@ -331,6 +338,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UI\RecordingToolControl.resx">
       <DependentUpon>RecordingToolControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UI\ToastNotifier.resx" >
+        <DependentUpon>ToastNotifier.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="app.config">
       <SubType>Designer</SubType>
@@ -433,7 +443,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
+using System.Reflection;
 using System.Windows.Forms;
 using DesktopAnalytics;
 using HearThis.Properties;
@@ -225,6 +226,14 @@ namespace HearThis
 			Analytics.ReportException(e.Exception);
 		}
 
+		public static bool RunningUnitTests
+		{
+			get
+			{
+				return Assembly.GetEntryAssembly() == null;
+			}
+		}
+
 		#region AppData folder structure
 		/// <summary>
 		/// Get the folder %AppData%/SIL/HearThis where we store recordings and localization stuff.
@@ -240,6 +249,20 @@ namespace HearThis
 						Program.kCompany, Program.kProduct);
 				}
 				return _sHearThisFolder;
+			}
+		}
+
+		/// <summary>
+		/// For now, a poor-man's channel-naming.
+		/// </summary>
+		public static string ChannelName
+		{
+			get
+			{
+#if DEBUG
+				return "alpha";
+#endif
+				return "release";
 			}
 		}
 

--- a/src/HearThis/UI/DiscontiguousProgressTrackBar.cs
+++ b/src/HearThis/UI/DiscontiguousProgressTrackBar.cs
@@ -139,8 +139,7 @@ namespace HearThis.UI
 			//draw the bar
 			e.Graphics.FillRectangle(AppPallette.DisabledBrush, kLeftMargin, top, BarWidth, 3);
 
-			Brush[] brushes = GetSegmentBrushesMethod();
-
+			var brushes = GetSegmentBrushesOrErrorBrushes();
 			try
 			{
 				// Do NOT make this an int, or rounding error mounts up as we multiply it by integers up to Maximum
@@ -174,6 +173,24 @@ namespace HearThis.UI
 #endif
 			}
 			// base.SetStyle(ControlStyles.UserPaint, true);
+		}
+
+		/// <summary>
+		/// See note on RecordingToolControl about all this error-wrapping
+		/// </summary>
+		private Brush[] GetSegmentBrushesOrErrorBrushes()
+		{
+			var brushes = GetSegmentBrushesMethod();
+			if(brushes == null)
+			{
+				brushes = new Brush[SegmentCount];
+				var errorBrush = new SolidBrush(Color.Chartreuse);
+				for(int i = 0; i < brushes.Length; i++)
+				{
+					brushes[i] = errorBrush;
+				}
+			}
+			return brushes;
 		}
 
 		public int SegmentCount

--- a/src/HearThis/UI/ToastNotifier.cs
+++ b/src/HearThis/UI/ToastNotifier.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace HearThis.UI
+{
+	/// <summary>
+	/// Like a notification balloon, but more reliable "toast" because it slowly goes up, then down.
+	/// Subscribe to the Click event to know if the user clicked on it.
+	/// Note: currently clicking on the image or text invoke the click event, not just the action link.
+	/// Note: don't use a lot of these. They hang around off-screen.  (See comment in GoDownTimerTick.)
+	/// It's primarily intended for something like "updates are available" that happens
+	/// once per run of the program.
+	/// Usage:
+	/// 		var notifier = new ToastNotifier();
+	///			notifier.Image.Image = {some small Image, about 32x32};
+	///			notifier.ToastClicked += (sender, args) => {do something};
+	///			notifier.Show("You should know this", "Something you might do about it", {some # of seconds});
+	///	You should NOT dispose of the notifier, since we haven't found a safe time to even close it.
+	/// </summary>
+	public partial class ToastNotifier : Form
+	{
+		private Timer _goUpTimer;
+		private Timer _goDownTimer;
+		private Timer _pauseTimer;
+		private int startPosX;
+		private int startPosY;
+		private int endPosY;	// minimum (highest on screen) desired value
+		private bool _stayUp;
+		private static string _currentMessage;
+
+		/// <summary>
+		/// The user clicked on the toast popup
+		/// </summary>
+		public event EventHandler ToastClicked;
+
+
+
+		/// <summary>
+		/// constructor
+		/// </summary>
+		public ToastNotifier()
+		{
+			InitializeComponent();
+			// We do NOT want our window to be the top most; that disables the effect of ShowWithoutActivation
+			// and means that the toast steals focus from our main window. Once brought up in front of our
+			// window (but not activated) it seems to stay there pretty nicely even while we interact with
+			// the window. See BL-1126.
+			//TopMost = true;
+			// Pop doesn't need to be shown in task bar
+			ShowInTaskbar = false;
+			// Create and run timer for animation
+			_goUpTimer = new Timer();
+			_goUpTimer.Interval = 50;
+			_goUpTimer.Tick += GoUpTimerTick;
+			_goDownTimer = new Timer();
+			_goDownTimer.Interval = 50;
+			_goDownTimer.Tick += GoDownTimerTick;
+			_pauseTimer = new Timer();
+			_pauseTimer.Interval = 15000;
+			_pauseTimer.Tick += PauseTimerTick;
+		}
+
+//		public Color BackgroundColor
+//		{
+//			set { this.color}
+//		}
+		/// <summary>
+		/// Stops it stealing focus from the main window even though it will be in front of that window.
+		/// </summary>
+		protected override bool ShowWithoutActivation
+		{
+			get { return true; }
+		}
+
+		//storing this here so that we only make one and don't have to worry about disposing of it
+		public static Image WarningBitmap = SystemIcons.Warning.ToBitmap();
+
+		private void PauseTimerTick(object sender, EventArgs e)
+		{
+			_pauseTimer.Stop();
+			_goDownTimer.Start();
+		}
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <param name="e"></param>
+		protected override void OnLoad(EventArgs e)
+		{
+			// Move window out of screen
+			startPosX = Screen.PrimaryScreen.WorkingArea.Width - Width;
+			startPosY = Screen.PrimaryScreen.WorkingArea.Height;
+			endPosY = startPosY - Height;
+			SetDesktopLocation(startPosX, startPosY);
+			//Debug.WriteLine(String.Format("DEBUG Toast.OnLoad(): after adjustments, Bounds = {0}", this.DesktopBounds));
+			base.OnLoad(e);
+			// Begin animation
+			_goUpTimer.Start();
+		}
+
+		void GoUpTimerTick(object sender, EventArgs e)
+		{
+			//Debug.WriteLine(String.Format("DEBUG Begin Toast.GoUpTimerTick(): Bounds = {0}", this.DesktopBounds));
+			//Lift window by 5 pixels
+			startPosY -= 5;
+			//If window is fully visible stop the timer
+			if (startPosY < endPosY)
+			{
+				_goUpTimer.Stop();
+				startPosY = endPosY;
+				SetDesktopLocation(startPosX, startPosY);
+				if(!_stayUp)
+					_pauseTimer.Start();
+			}
+			else
+			{
+				SetDesktopLocation(startPosX, startPosY);
+			}
+			this.Refresh();
+			//Debug.WriteLine(String.Format("DEBUG End Toast.GoUpTimerTick(): Bounds = {0}", this.DesktopBounds));
+		}
+
+		private void GoDownTimerTick(object sender, EventArgs e)
+		{
+			//Debug.WriteLine(String.Format("DEBUG Begin Toast.GoDownTimerTick(): Bounds = {0}", this.DesktopBounds));
+			//Lower window by 5 pixels
+			startPosY += 5;
+			//If window is fully visible stop the timer
+			if (startPosY > Screen.PrimaryScreen.Bounds.Height)
+			{
+#if __MonoCS__
+				// The window doesn't move onto and off the screen on Wasta 14 Linux for some reason.  I suspect some sort of system setting,
+				// not Mono, since it works fine on Trusty Linux and the Bounds values all look correct on Wasta 14.  So we'll just make this
+				// form invisible at the right time.  This should not hurt anything on Trusty, but I'm marking it for Mono only just in case
+				// setting Visible has the same wierd bug on Windows as calling Close().
+				this.Visible = false;
+#endif
+				_goDownTimer.Stop();
+				//If the client app starts with a "show dialog" open (e.g., selecting a file to open), this Close() actually closes *that* dialog, which is, um, bad.
+				//So I'm just going to not do the close, figuring that it only runs once per run of the application anyhow
+				//Close();
+
+				_currentMessage = null;
+
+			}
+			else
+			{
+				SetDesktopLocation(startPosX, startPosY);
+				this.Refresh();
+			}
+			//Debug.WriteLine(String.Format("DEBUG End Toast.GoDownTimerTick(): Bounds = {0}", this.DesktopBounds));
+		}
+
+		private void ToastNotifier_Click(object sender, EventArgs e)
+		{
+			EventHandler handler = ToastClicked;
+			ToastClicked = null;	// handle only one click message. (Linux posts two if link clicked, one for Toast window in general.)
+			if (handler != null)
+				handler(this, e);
+			// We may still have a message pending for the sender even though it has already been disposed.
+			// This would cause a System.ObjectDisposedException shortly if we call Close() directly from
+			// here, so we add a method to close this ToastNotifier to the Application.Idle processor (which
+			// won't fire until all of the current pending messages have been handled).  See BL-3285.
+			Application.Idle += CloseThisLater;
+		}
+
+		private void CloseThisLater(object sender, EventArgs e)
+		{
+			Application.Idle -= CloseThisLater;
+			DialogResult = DialogResult.Yes;
+			this.Close();
+		}
+
+		/// <summary>
+		/// Show the toast
+		/// </summary>
+		/// <param name="message"></param>
+		/// <param name="callToAction">Text of the hyperlink </param>
+		/// <param name="seconds">How long to show before it goes back down</param>
+		public void Show(string message, string callToAction, int seconds)
+		{
+			//avoid showing a blizzard of the same message
+			if(message == _currentMessage)
+				return;
+			_currentMessage = message;
+			_message.Text = message;
+			_callToAction.Text = callToAction;
+			if (seconds < 0)
+			{
+				_stayUp = true; //just leave it up permanently
+			}
+			else
+			{
+				_pauseTimer.Interval = 1000 * seconds;
+			}
+			Show();
+		}
+
+		public void UpdateMessage(string newMessage)
+		{
+			_message.Text = newMessage;
+		}
+
+		private void callToAction_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+		{
+			this.ToastNotifier_Click(null, null);
+		}
+	}
+}

--- a/src/HearThis/UI/ToastNotifier.designer.cs
+++ b/src/HearThis/UI/ToastNotifier.designer.cs
@@ -1,0 +1,114 @@
+﻿namespace HearThis.UI
+{
+	partial class ToastNotifier
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.components = new System.ComponentModel.Container();
+			this._message = new System.Windows.Forms.Label();
+			this.Image = new System.Windows.Forms.PictureBox();
+			this.imageList1 = new System.Windows.Forms.ImageList(this.components);
+			this._callToAction = new System.Windows.Forms.LinkLabel();
+			((System.ComponentModel.ISupportInitialize)(this.Image)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// _message
+			// 
+			this._message.AutoSize = true;
+			this._message.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this._message.Location = new System.Drawing.Point(50, 9);
+			this._message.MaximumSize = new System.Drawing.Size(240, 0);
+			this._message.Name = "_message";
+			this._message.Size = new System.Drawing.Size(239, 36);
+			this._message.TabIndex = 2;
+			this._message.Text = "Notification Text That may take two lines";
+			this._message.Click += new System.EventHandler(this.ToastNotifier_Click);
+			// 
+			// Image
+			// 
+			this.Image.Location = new System.Drawing.Point(6, 9);
+			this.Image.Name = "Image";
+			this.Image.Size = new System.Drawing.Size(39, 43);
+			this.Image.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+			this.Image.TabIndex = 3;
+			this.Image.TabStop = false;
+			this.Image.Click += new System.EventHandler(this.ToastNotifier_Click);
+			// 
+			// imageList1
+			// 
+			this.imageList1.ColorDepth = System.Windows.Forms.ColorDepth.Depth8Bit;
+			this.imageList1.ImageSize = new System.Drawing.Size(16, 16);
+			this.imageList1.TransparentColor = System.Drawing.Color.Transparent;
+			// 
+			// _callToAction
+			// 
+			this._callToAction.AutoSize = true;
+			this._callToAction.Location = new System.Drawing.Point(51, 47);
+			this._callToAction.Name = "_callToAction";
+			this._callToAction.Size = new System.Drawing.Size(55, 13);
+			this._callToAction.TabIndex = 4;
+			this._callToAction.TabStop = true;
+			this._callToAction.Text = "linkLabel1";
+			this._callToAction.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.callToAction_LinkClicked);
+			this._callToAction.Click += new System.EventHandler(this.ToastNotifier_Click);
+			// 
+			// ToastNotifier
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.BackColor = System.Drawing.Color.White;
+			this.ClientSize = new System.Drawing.Size(296, 64);
+			this.ControlBox = false;
+			this.Controls.Add(this._callToAction);
+			this.Controls.Add(this.Image);
+			this.Controls.Add(this._message);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "ToastNotifier";
+			this.ShowIcon = false;
+			this.ShowInTaskbar = false;
+			this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+			this.Click += new System.EventHandler(this.ToastNotifier_Click);
+			((System.ComponentModel.ISupportInitialize)(this.Image)).EndInit();
+			this.ResumeLayout(false);
+			this.PerformLayout();
+
+		}
+
+		#endregion
+
+        private System.Windows.Forms.Label _message;
+        private System.Windows.Forms.ImageList imageList1;
+        
+        /// <summary>
+        /// Image of your app
+        /// </summary>
+        public System.Windows.Forms.PictureBox Image;
+        private System.Windows.Forms.LinkLabel _callToAction;
+	}
+}

--- a/src/HearThis/UI/ToastNotifier.resx
+++ b/src/HearThis/UI/ToastNotifier.resx
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/HearThis/Utils/NonFatalProblem.cs
+++ b/src/HearThis/Utils/NonFatalProblem.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using DesktopAnalytics;
+using HearThis.UI;
+using SIL.Reporting;
+
+namespace HearThis
+{
+	// NB: these must have the exactly the same symbols
+	public enum ModalIf { None, Alpha, Beta, All }
+	public enum PassiveIf { None, Alpha, Beta, All }
+
+	/// <summary>
+	/// Provides a way to note a problem in the log and, depending on channel, notify the user.
+	/// </summary>
+	public static class NonFatalProblem
+	{
+		/// <summary>
+		/// Always log, possibly inform the user, possibly throw the exception
+		/// </summary>
+		/// <param name="modalThreshold">Will show a modal dialog if the channel is this or lower</param>
+		/// <param name="passiveThreshold">Ignored for now</param>
+		/// <param name="shortUserLevelMessage">Simple message that fits in small toast notification</param>
+		/// <param name="moreDetails">Info adds information about the problem, which we get if they report the problem</param>
+		/// <param name="exception"></param>
+		public static void Report(ModalIf modalThreshold, PassiveIf passiveThreshold, string shortUserLevelMessage = null,
+			string moreDetails = null,
+			Exception exception = null)
+		{
+			// Simplify some checks below by tweaking the channel name on Linux.
+			var channel = Program.ChannelName.ToLowerInvariant();
+			if (channel.EndsWith("-unstable"))
+				channel = channel.Replace("unstable", "alpha");
+			try
+			{
+				shortUserLevelMessage = shortUserLevelMessage == null ? "" : shortUserLevelMessage;
+				var fullDetailedMessage = shortUserLevelMessage;
+				if (!string.IsNullOrEmpty(moreDetails))
+					fullDetailedMessage = fullDetailedMessage + System.Environment.NewLine + moreDetails;
+
+				if (exception == null)
+				{
+					try
+					{
+						throw new ApplicationException("Not actually an exception, just a message.");
+					}
+					catch (Exception errorToGetStackTrace)
+					{
+						exception = errorToGetStackTrace;
+					}
+				}
+
+				if (Program.RunningUnitTests)
+				{
+					//It's not clear to me what we can do that works for all unit test scenarios...
+					//We can imagine those for which throwing an exception at this point would be helpful,
+					//but there are others in which say, not finding a file is expected. Either way,
+					//the rest of the test should fail if the problem is real, so doing anything here
+					//would just be a help, not really necessary for getting the test to fail. 
+					//So, for now I'm going to just go with doing nothing.
+					return;
+				}
+
+				//if this isn't going modal even for devs, it's just background noise and we don't want the 
+				//thousands of exceptions we were getting as with BL-3280
+				if (modalThreshold != ModalIf.None)
+				{
+					Analytics.ReportException(exception);
+				}
+
+				Logger.WriteError("NonFatalProblem: " + fullDetailedMessage, exception);
+
+				if (Matches(modalThreshold).Any(s => channel.Contains(s)))
+				{
+					try
+					{
+						SIL.Reporting.ErrorReport.ReportNonFatalExceptionWithMessage(exception, fullDetailedMessage);
+					}
+					catch (Exception)
+					{
+						//if we're running when the UI is already shut down, the above is going to throw.
+						//At least if we're running in a debugger, we'll stop here:
+						throw new ApplicationException(fullDetailedMessage + "Error trying to report normally.");
+					}
+					return;
+				}
+
+				//just convert from InformIf to ThrowIf so that we don't have to duplicate code
+				var passive = (ModalIf)ModalIf.Parse(typeof(ModalIf), passiveThreshold.ToString());
+				if (!string.IsNullOrEmpty(shortUserLevelMessage) && Matches(passive).Any(s => channel.Contains(s)))
+				{
+
+					ShowToast(shortUserLevelMessage, exception, fullDetailedMessage);
+				}
+			}
+			catch (Exception errorWhileReporting)
+			{
+				if (channel.Contains("alpha"))
+					ErrorReport.NotifyUserOfProblem(errorWhileReporting, "Error while reporting non fatal error");
+			}
+		}
+
+		private static void ShowToast(string shortUserLevelMessage, Exception exception, string fullDetailedMessage)
+		{
+			var formForSynchronizing = Application.OpenForms.Cast<Form>().Last();
+			if (formForSynchronizing.InvokeRequired)
+			{
+				formForSynchronizing.BeginInvoke(new Action(() =>
+				{
+					ShowToast(shortUserLevelMessage, exception, fullDetailedMessage);
+				}));
+				return;
+			}
+			var toast = new ToastNotifier();
+			toast.ToastClicked +=
+				(s, e) => { SIL.Reporting.ErrorReport.ReportNonFatalExceptionWithMessage(exception, fullDetailedMessage); };
+			toast.Image.Image = ToastNotifier.WarningBitmap;
+			toast.Show(shortUserLevelMessage, "Report", 5);
+		}
+
+		private static IEnumerable<string> Matches(ModalIf threshold)
+		{
+			switch (threshold)
+			{
+				case ModalIf.All:
+					return new string[] { "" /*will match anything*/};
+				case ModalIf.Beta:
+					return new string[] { "developer", "alpha", "beta" };
+				case ModalIf.Alpha:
+					return new string[] { "developer", "alpha" };
+				default:
+					return new string[] { };
+			}
+		}
+	}
+}


### PR DESCRIPTION
Brought in a couple classes from Bloom that we have found helpful in dealing with these hard-to-reproduce errors. They allow us to show a "toast" that can be ignored or clicked on to send a report.

Also retrying getting brushes a couple times in case this is a timing bug. Also fall back to an all-green trackbar if even that fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/7)
<!-- Reviewable:end -->
