### PR TITLE
Update build.proj to fix uploaded file owner

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -106,7 +106,7 @@
 
 	<!--  push up to the on software.sil.org download page -->
 	<Message Text="Attempting rsync of download info file to software.sil.org" Importance="high"/>
-	<Exec Command ='"c:\program files\cwRsync\bin\rsync.exe" -vzlt --chmod=Dug=rwx,Fu=rw,go=r --stats --rsync-path="rsync" -e"\"c:\program files\cwRsync\bin\ssh\" -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=/cygdrive/c/BuildAgent/conf/bob.key -l root"  "../output/installer/HearThisInstaller.$(Version).download_info" root@software.sil.org:/var/www/virtual/software.sil.org/htdocs/downloads/r/hearthis/' />
+	<Exec Command ='"c:\program files\cwRsync\bin\rsync.exe" -vzlt --chmod=Dug=rwx,Fu=rw,go=r --stats --rsync-path="sudo -u vu2004 rsync" -e"\"c:\program files\cwRsync\bin\ssh\" -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=/cygdrive/c/BuildAgent/conf/bob.key -l root"  "../output/installer/HearThisInstaller.$(Version).download_info" root@software.sil.org:/var/www/virtual/software.sil.org/htdocs/downloads/r/hearthis/' />
   </Target>
 
 
@@ -115,7 +115,7 @@
 
 	<!-- put installer on software.sil.org-->
 	<Message Text="Attempting rsync of HearThisInstaller-$(Version).msi to software.sil.org" Importance="high"/>
-	<Exec Command ='"c:\program files\cwRsync\bin\rsync.exe" -vzlt --chmod=Dug=rwx,Fu=rw,go=r --stats --rsync-path="rsync" -e"\"c:\program files\cwRsync\bin\ssh\" -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=/cygdrive/c/BuildAgent/conf/bob.key -l root"  "../output/installer/HearThisInstaller-$(Version).msi" root@software.sil.org:/var/www/virtual/software.sil.org/htdocs/downloads/r/hearthis/' />
+	<Exec Command ='"c:\program files\cwRsync\bin\rsync.exe" -vzlt --chmod=Dug=rwx,Fu=rw,go=r --stats --rsync-path="sudo -u vu2004 rsync" -e"\"c:\program files\cwRsync\bin\ssh\" -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=/cygdrive/c/BuildAgent/conf/bob.key -l root"  "../output/installer/HearThisInstaller-$(Version).msi" root@software.sil.org:/var/www/virtual/software.sil.org/htdocs/downloads/r/hearthis/' />
 
 	<CallTarget Targets ='MakeDownloadPointers'/>
   </Target>


### PR DESCRIPTION
Adding sudo -u vu2004 to the --rsync-path will cause the uploaded files to be owned by vu2004 which is the same user that would operate FTP.  This allows product teams to use a tool like Filezilla to delete old files from time to time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/8)
<!-- Reviewable:end -->
