### PR TITLE
Delay setting up check for updated version until after main window is…

### DIFF
--- a/src/HearThis/Properties/AssemblyInfo.cs
+++ b/src/HearThis/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 // These version nhumbers are ignored. See build.proj file and counter on
-// TeamCity configuration for actuall version numbers.
+// TeamCity configuration for actual version numbers.
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -61,10 +61,6 @@ namespace HearThis.UI
 
 			InitializeModesCombo();
 
-			UpdateChecker = new Sparkle(
-				@"http://build.palaso.org/guestAuth/repository/download/bt90/.lastSuccessful/appcast.xml",
-				(System.Drawing.Icon) (new ComponentResourceManager(this.GetType()).GetObject("$this.Icon")));
-			UpdateChecker.CheckOnFirstApplicationIdle();
 			// Todo: possibly make this conditional on an a device being connected.
 			// If possible notice and show it when a device is later connected.
 			// Or: possibly if no device is active it displays instructions.
@@ -127,6 +123,12 @@ namespace HearThis.UI
 				StartPosition = FormStartPosition.CenterScreen;
 				WindowState = FormWindowState.Maximized;
 			}
+
+			UpdateChecker = new Sparkle(@"http://build.palaso.org/guestAuth/repository/download/bt90/.lastSuccessful/appcast.xml",
+				Icon);
+			// We don't want to do this until the main window is loaded because a) it's very easy for the user to overlook, and b)
+			// more importantly, when the toast notifier closes, it can sometimes clobber an error message being displayed for the user.
+			UpdateChecker.CheckOnFirstApplicationIdle();
 		}
 
 		/// <summary>


### PR DESCRIPTION
… loaded to prevent weird UX when ToastNotifier window closes (which might having an error message get clobbered).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/11)
<!-- Reviewable:end -->
