### PR TITLE
HT-187: Fixed bugs related to the "Sparkle" code to get the latest version of HT 1.5

### DIFF
--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -51,7 +51,10 @@ the recorded files to that format, if necessary.
 
 # Release Notes
 
-## 1.4 Sept 2016
+## 1.5 November 2016
+Added support for Paratext 8 projects. HearThis 1.4.x should be used for Paratext 7 projects.
+
+## 1.4 September 2016
 Increased time we wait for external audio merger/converters to finish, from 1 minute to 10 minutes.
 
 ## 1.3 May 2016

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -124,7 +124,7 @@ namespace HearThis.UI
 				WindowState = FormWindowState.Maximized;
 			}
 
-			UpdateChecker = new Sparkle(@"http://build.palaso.org/guestAuth/repository/download/bt90/.lastSuccessful/appcast.xml",
+			UpdateChecker = new Sparkle(@"http://build.palaso.org/guestAuth/repository/download/HearThis_HearThisWinDevPublishPt8/.lastSuccessful/appcast.xml",
 				Icon);
 			// We don't want to do this until the main window is loaded because a) it's very easy for the user to overlook, and b)
 			// more importantly, when the toast notifier closes, it can sometimes clobber an error message being displayed for the user.

--- a/src/Installer/appcast.xml
+++ b/src/Installer/appcast.xml
@@ -2,15 +2,15 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
 	<channel>
 		<title>HearThis Releases</title>
-		<link>http://hearthis.palaso.org/download/</link>
+		<link>http://software.sil.org/hearthis/download/</link>
 		<description>Most recent changes with links to updates.</description>
 		<language>en</language>
 		<item>
 			<title>Version DEV_VERSION_NUMBER</title>
 			<sparkle:releaseNotesLink>
-				http://build.palaso.org/guestAuth/repository/download/bt90/.lastSuccessful/ReleaseNotes.md
+				http://build.palaso.org/guestAuth/repository/download/HearThis_HearThisWinDevPublishPt8/.lastSuccessful/ReleaseNotes.md
 			</sparkle:releaseNotesLink>
-			<enclosure url="http://software.sil.org/downloads/hearthis/HearThisInstaller-DEV_VERSION_NUMBER.msi" sparkle:version="DEV_VERSION_NUMBER" type="application/octet-stream" />
+			<enclosure url="http://software.sil.org/downloads/r/hearthis/HearThisInstaller-DEV_VERSION_NUMBER.msi" sparkle:version="DEV_VERSION_NUMBER" type="application/octet-stream" />
 		</item>
 
 	</channel>


### PR DESCRIPTION
HT-188: Changed appcast.xml for 1.5 branch to look for the latest version in the 1.5 and the code to look for the appcast.xml file from the latest successful 1.5 build.
HT-190: Updated the link URL in appcast.XML to point to software.sil.org/hearthis/download
HT-191: Updated release notes to indicate support for Paratext 8 projects and distinguish between HT 1.4.x and 1.5.x.
HT-192: Updated the enclosure URL (to access the latest msi) in appcast.XML to include the /r folder so we don't get a 404.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/13)
<!-- Reviewable:end -->
