### PR TITLE
HT-187: Fixed 404 (URL not found) trying to access HT 1.4 upgrades

### DIFF
--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -51,7 +51,10 @@ the recorded files to that format, if necessary.
 
 # Release Notes
 
-## 1.4 Sept 2016
+## 1.5 November 2016
+Added support for Paratext 8 projects. HearThis 1.4.x should be used for Paratext 7 projects.
+
+## 1.4 September 2016
 Increased time we wait for external audio merger/converters to finish, from 1 minute to 10 minutes.
 
 ## 1.3 May 2016

--- a/src/Installer/appcast.xml
+++ b/src/Installer/appcast.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
 	<channel>
 		<title>HearThis Releases</title>
-		<link>http://hearthis.palaso.org/download/</link>
+		<link>http://software.sil.org/hearthis/download/</link>
 		<description>Most recent changes with links to updates.</description>
 		<language>en</language>
 		<item>
@@ -10,7 +10,7 @@
 			<sparkle:releaseNotesLink>
 				http://build.palaso.org/guestAuth/repository/download/bt90/.lastSuccessful/ReleaseNotes.md
 			</sparkle:releaseNotesLink>
-			<enclosure url="http://software.sil.org/downloads/hearthis/HearThisInstaller-DEV_VERSION_NUMBER.msi" sparkle:version="DEV_VERSION_NUMBER" type="application/octet-stream" />
+			<enclosure url="http://software.sil.org/downloads/r/hearthis/HearThisInstaller-DEV_VERSION_NUMBER.msi" sparkle:version="DEV_VERSION_NUMBER" type="application/octet-stream" />
 		</item>
 
 	</channel>


### PR DESCRIPTION
HT-190: Updated the link URL in appcast.XML to point to software.silorg/hearthis/download
HT-191: Updated release notes to indicate support for Paratext 8 projects and distinguish between HT 1.4.x and 1.5.x.
HT-192: Updated the enclosure URL (to access the latest msi) in appcast.XML to include the /r folder so we don't get a 404.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/14)
<!-- Reviewable:end -->
