### PR TITLE
HT 201: Switch from NuGet's version of NetSparkle to the SILLsDev version, which fails quietly if not connected to the Internet.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ lib/dotnet/SIL.*.pdb
 lib/dotnet/Ionic.Zip.dll
 lib/dotnet/ICSharpCode.SharpZipLib.dll
 lib/dotnet/icu*.dll
+lib/dotnet/NetSparkle.Net40.dll

--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -51,8 +51,11 @@ the recorded files to that format, if necessary.
 
 # Release Notes
 
-## 1.6 January 2017
-Added support for recording passages of poetry in which you want to separate text at paragraph markes, instead of just punctuation. See Settings:Punctuation.
+## February 2017
+Fixed bug that cause HearThis to crash when not connected to the Internet.
+
+## January 2017
+Added support for recording passages of poetry in which you want to separate text at paragraph markes, instead of just punctuation. See Settings:Punctuation. This change was incoporated into both 1.4 (for Paratext 7) and 1.5 (for Paratext 8).
 
 ## 1.5 November 2016
 Added support for Paratext 8 projects. HearThis 1.4.x should be used for Paratext 7 projects.

--- a/build/getDependencies-windows.sh
+++ b/build/getDependencies-windows.sh
@@ -67,12 +67,19 @@ cd -
 
 
 # *** Results ***
-# build: HearThis-Win-Dev-Continuous (bt89)
+# build: HearThis-Win-1.4 (PT7)-Continuous (bt89)
 # project: HearThis
 # URL: http://build.palaso.org/viewType.html?buildTypeId=bt89
-# VCS: https://github.com/sillsdev/HearThis.git [master]
+# VCS: https://github.com/sillsdev/HearThis.git [Version1.4]
 # dependencies:
-# [0] build: palaso-win32-master-nostrongname Continuous (bt436)
+# [0] build: NetSparkle Continuous (NetSparkle_NetSparkleContinuous)
+#     project: NetSparkle
+#     URL: http://build.palaso.org/viewType.html?buildTypeId=NetSparkle_NetSparkleContinuous
+#     clean: false
+#     revision: latest.lastSuccessful
+#     paths: {"*.dll"=>""}
+#     VCS: https://github.com/sillsdev/NetSparkle [master]
+# [1] build: palaso-win32-master-nostrongname Continuous (bt436)
 #     project: libpalaso
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt436
 #     clean: false
@@ -81,10 +88,12 @@ cd -
 #     VCS: https://github.com/sillsdev/libpalaso.git []
 
 # make sure output directories exist
+mkdir -p ../
 mkdir -p ../build/
 mkdir -p ../lib/dotnet
 
 # download artifact dependencies
+copy_auto http://build.palaso.org/guestAuth/repository/download/NetSparkle_NetSparkleContinuous/latest.lastSuccessful/NetSparkle.Net40.dll ../lib/dotnet/NetSparkle.Net40.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.4.tcbuildtag/Palaso.BuildTasks.dll ../build/Palaso.BuildTasks.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.4.tcbuildtag/Ionic.Zip.dll ../lib/dotnet/Ionic.Zip.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.4.tcbuildtag/L10NSharp.dll ../lib/dotnet/L10NSharp.dll

--- a/src/HearThis/HearThis.csproj
+++ b/src/HearThis/HearThis.csproj
@@ -99,8 +99,8 @@
       <HintPath>..\..\lib\dotnet\NetLoc.XmlSerializers.dll</HintPath>
     </Reference>
     <Reference Include="NetSparkle.Net40, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NetSparkle.1.1.0\lib\net40-full\NetSparkle.Net40.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\dotnet\NetSparkle.Net40.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>

--- a/src/HearThis/packages.config
+++ b/src/HearThis/packages.config
@@ -3,7 +3,6 @@
   <package id="Analytics" version="2.0.0" targetFramework="net40-Client" />
   <package id="DesktopAnalytics" version="1.1.2" targetFramework="net40-Client" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net4-client" />
-  <package id="NetSparkle" version="1.1.0" targetFramework="net40-client" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40-Client" />
   <package id="ZXing.Net" version="0.14.0.1" targetFramework="net40-Client" />
 </packages>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/19)
<!-- Reviewable:end -->
