### PR TITLE
HT-206: Made HT 1.5 branch work with Paratext 8

### DIFF
--- a/build/getDependencies-windows.sh
+++ b/build/getDependencies-windows.sh
@@ -67,53 +67,52 @@ cd -
 
 
 # *** Results ***
-# build: HearThis-Win-Dev-Continuous-PT8 (HearThis_HearThisWinDevContinuousPt8)
+# build: HearThis-Win-1.5 (PT8)-Continuous (HearThis_HearThisWinDevContinuousPt8)
 # project: HearThis
 # URL: http://build.palaso.org/viewType.html?buildTypeId=HearThis_HearThisWinDevContinuousPt8
-# VCS: https://github.com/sillsdev/HearThis.git [SupportPT8]
+# VCS: https://github.com/sillsdev/HearThis.git [master]
 # dependencies:
 # [0] build: NetSparkle Continuous (NetSparkle_NetSparkleContinuous)
 #     project: NetSparkle
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=NetSparkle_NetSparkleContinuous
 #     clean: false
 #     revision: latest.lastSuccessful
-#     paths: {"*.dll"=>""}
+#     paths: {"*.dll"=>"lib/dotnet"}
 #     VCS: https://github.com/sillsdev/NetSparkle [master]
 # [1] build: palaso-win32-master-nostrongname Continuous (bt436)
 #     project: libpalaso
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt436
 #     clean: false
-#     revision: latest.lastSuccessful
+#     revision: hearthis-1.5.tcbuildtag
 #     paths: {"Palaso.BuildTasks.dll"=>"build/", "Ionic.Zip.dll"=>"lib/dotnet", "L10NSharp.dll"=>"lib/dotnet", "L10NSharp.pdb"=>"lib/dotnet", "SIL.Core.dll"=>"lib/dotnet", "SIL.Core.pdb"=>"lib/dotnet", "SIL.DblBundle.dll"=>"lib/dotnet", "SIL.DblBundle.pdb"=>"lib/dotnet", "SIL.Media.dll"=>"lib/dotnet", "SIL.Media.pdb"=>"lib/dotnet", "SIL.Scripture.dll"=>"lib/dotnet", "SIL.Scripture.pdb"=>"lib/dotnet", "SIL.Windows.Forms.dll"=>"lib/dotnet", "SIL.Windows.Forms.pdb"=>"lib/dotnet", "SIL.Windows.Forms.DblBundle.dll"=>"lib/dotnet", "SIL.Windows.Forms.DblBundle.pdb"=>"lib/dotnet", "SIL.WritingSystems.dll"=>"lib/dotnet", "SIL.WritingSystems.pdb"=>"lib/dotnet", "icu.net.dll"=>"lib/dotnet", "icudt54.dll"=>"lib/dotnet", "icuin54.dll"=>"lib/dotnet", "icuuc54.dll"=>"lib/dotnet"}
 #     VCS: https://github.com/sillsdev/libpalaso.git []
 
 # make sure output directories exist
-mkdir -p ../
 mkdir -p ../build/
 mkdir -p ../lib/dotnet
 
 # download artifact dependencies
 copy_auto http://build.palaso.org/guestAuth/repository/download/NetSparkle_NetSparkleContinuous/latest.lastSuccessful/NetSparkle.Net40.dll ../lib/dotnet/NetSparkle.Net40.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/Palaso.BuildTasks.dll?branch=%3Cdefault%3E ../build/Palaso.BuildTasks.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/Ionic.Zip.dll?branch=%3Cdefault%3E ../lib/dotnet/Ionic.Zip.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/L10NSharp.dll?branch=%3Cdefault%3E ../lib/dotnet/L10NSharp.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/L10NSharp.pdb?branch=%3Cdefault%3E ../lib/dotnet/L10NSharp.pdb
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.Core.dll?branch=%3Cdefault%3E ../lib/dotnet/SIL.Core.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.Core.pdb?branch=%3Cdefault%3E ../lib/dotnet/SIL.Core.pdb
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.DblBundle.dll?branch=%3Cdefault%3E ../lib/dotnet/SIL.DblBundle.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.DblBundle.pdb?branch=%3Cdefault%3E ../lib/dotnet/SIL.DblBundle.pdb
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.Media.dll?branch=%3Cdefault%3E ../lib/dotnet/SIL.Media.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.Media.pdb?branch=%3Cdefault%3E ../lib/dotnet/SIL.Media.pdb
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.Scripture.dll?branch=%3Cdefault%3E ../lib/dotnet/SIL.Scripture.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.Scripture.pdb?branch=%3Cdefault%3E ../lib/dotnet/SIL.Scripture.pdb
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.Windows.Forms.dll?branch=%3Cdefault%3E ../lib/dotnet/SIL.Windows.Forms.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.Windows.Forms.pdb?branch=%3Cdefault%3E ../lib/dotnet/SIL.Windows.Forms.pdb
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.Windows.Forms.DblBundle.dll?branch=%3Cdefault%3E ../lib/dotnet/SIL.Windows.Forms.DblBundle.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.Windows.Forms.DblBundle.pdb?branch=%3Cdefault%3E ../lib/dotnet/SIL.Windows.Forms.DblBundle.pdb
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.WritingSystems.dll?branch=%3Cdefault%3E ../lib/dotnet/SIL.WritingSystems.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/SIL.WritingSystems.pdb?branch=%3Cdefault%3E ../lib/dotnet/SIL.WritingSystems.pdb
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/icu.net.dll?branch=%3Cdefault%3E ../lib/dotnet/icu.net.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/icudt54.dll?branch=%3Cdefault%3E ../lib/dotnet/icudt54.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/icuin54.dll?branch=%3Cdefault%3E ../lib/dotnet/icuin54.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/latest.lastSuccessful/icuuc54.dll?branch=%3Cdefault%3E ../lib/dotnet/icuuc54.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/Palaso.BuildTasks.dll ../build/Palaso.BuildTasks.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/Ionic.Zip.dll ../lib/dotnet/Ionic.Zip.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/L10NSharp.dll ../lib/dotnet/L10NSharp.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/L10NSharp.pdb ../lib/dotnet/L10NSharp.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.Core.dll ../lib/dotnet/SIL.Core.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.Core.pdb ../lib/dotnet/SIL.Core.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.DblBundle.dll ../lib/dotnet/SIL.DblBundle.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.DblBundle.pdb ../lib/dotnet/SIL.DblBundle.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.Media.dll ../lib/dotnet/SIL.Media.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.Media.pdb ../lib/dotnet/SIL.Media.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.Scripture.dll ../lib/dotnet/SIL.Scripture.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.Scripture.pdb ../lib/dotnet/SIL.Scripture.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.Windows.Forms.dll ../lib/dotnet/SIL.Windows.Forms.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.Windows.Forms.pdb ../lib/dotnet/SIL.Windows.Forms.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.Windows.Forms.DblBundle.dll ../lib/dotnet/SIL.Windows.Forms.DblBundle.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.Windows.Forms.DblBundle.pdb ../lib/dotnet/SIL.Windows.Forms.DblBundle.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.WritingSystems.dll ../lib/dotnet/SIL.WritingSystems.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/SIL.WritingSystems.pdb ../lib/dotnet/SIL.WritingSystems.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/icu.net.dll ../lib/dotnet/icu.net.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/icudt54.dll ../lib/dotnet/icudt54.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/icuin54.dll ../lib/dotnet/icuin54.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt436/hearthis-1.5.tcbuildtag/icuuc54.dll ../lib/dotnet/icuuc54.dll
 # End of script

--- a/build/readme - making getDependencies script.txt
+++ b/build/readme - making getDependencies script.txt
@@ -1,10 +1,10 @@
 Rebuilding this requires ruby and https://github.com/chrisvire/BuildUpdate
 Here's the command line I used:
 
-<your path to buildupdate.rb>\buildupdate.rb -t bt89 -f getDependencies-windows.sh -r ..
+<your path to buildupdate.rb>\buildupdate.rb -t HearThis_HearThisWinDevContinuousPt8 -f getDependencies-windows.sh -r ..
 
 Explanation:
 
-"-t bt89" points at the configuration that tracks this branch
+"-t HearThis_HearThisWinDevContinuousPt8" points at the configuration that tracks this branch
 "-f ____" gives what I want the file to be called
 "-r .." takes care of moving the context up from build to the root directory

--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -23,7 +23,6 @@ using SIL.Reporting;
 using Paratext;
 using Paratext.Users;
 using SIL.WritingSystems;
-using Utilities;
 
 namespace HearThis
 {
@@ -96,8 +95,7 @@ namespace HearThis
 					ScrTextCollection.Initialize();
 					userName = RegistrationInfo.UserName;
 					emailAddress = RegistrationInfo.EmailAddress;
-					foreach (var errMsgInfo in ScrTextCollection.ErrorMessages.Where(
-						e => e.ProjecType != ProjectType.Resource && e.Reason == UnsupportedReason.Unspecified))
+					foreach (var errMsgInfo in CompatibleParatextProjectLoadErrors.Where(e => e.Reason == UnsupportedReason.Unspecified))
 					{
 						_pendingExceptionsToReportToAnalytics.Add(errMsgInfo.Exception);
 					}
@@ -181,6 +179,8 @@ namespace HearThis
 				}
 			}
 		}
+
+		public static IEnumerable<ErrorMessageInfo> CompatibleParatextProjectLoadErrors => ScrTextCollection.ErrorMessages.Where(e => e.ProjecType != ProjectType.Resource && !e.ProjecType.IsNoteType());
 
 		public static string GetUserConfigFilePath()
 		{

--- a/src/HearThis/UI/ChooseProject.cs
+++ b/src/HearThis/UI/ChooseProject.cs
@@ -51,7 +51,7 @@ namespace HearThis.UI
 			try
 			{
 				paratextProjects = ScrTextCollection.ScrTexts(IncludeProjects.AccessibleScripture).ToArray();
-				var loadErrors = ScrTextCollection.ErrorMessages.Where(e => e.ProjecType != ProjectType.Resource).ToList();
+				var loadErrors = Program.CompatibleParatextProjectLoadErrors.ToList();
 				if (loadErrors.Any())
 				{
 					StringBuilder sb = new StringBuilder(LocalizationManager.GetString("ChooseProject.ParatextProjectLoadErrors",
@@ -171,14 +171,14 @@ namespace HearThis.UI
 		protected override void OnShown(EventArgs e)
 		{
 			base.OnShown(e);
-			if (IsParatext8Installed)
+			if (ParatextUtils.IsParatext7Installed)
 			{
 				const string downloadUrl = "http://software.sil.org/hearthis/download/";
 				var msgFmt = LocalizationManager.GetString("ChooseProject.Paratext8RequiresHT15",
-					"It looks like {0} is installed on this computer. To access {0} projects, you will need to install {1} or " +
-					"later from\n{2}\nThis is not an automatic upgrade.",
-					"Param 0: \"Paratext 8\"; Param 1: \"HearThis 1.5\"; Param 2: \"http://software.sil.org/hearthis/download/\"");
-				MessageBox.Show(this, String.Format(msgFmt, "Paratext 8", ProductName + " 1.5", downloadUrl), ProductName, MessageBoxButtons.OK, MessageBoxIcon.Information);
+					"It looks like {0} is installed on this computer. To access {0} projects, you will need to install a version of {1} " +
+					"earlier than {2} from\n{3}\nThis is the correct version for accessing {4} projects.",
+					"Param 0: \"Paratext 7\"; Param 1: \"HearThis\"; Param 2: \"1.5\"; Param 3: \"http://software.sil.org/hearthis/download/\"; Param 4: \"Paratext 8\"");
+				MessageBox.Show(this, String.Format(msgFmt, "Paratext 7", ProductName, " 1.5", downloadUrl, "Paratext 8"), ProductName, MessageBoxButtons.OK, MessageBoxIcon.Information);
 			}
 		}
 


### PR DESCRIPTION
Updated dependencies script (and dependencies on TC) to peg to an older version of libpalaso that has a version of icu.net.dll that is compatible with Paratext 8.
Also, changed check and corresponding message to tell user about using an earlier version of HT if PT7 is installed.
DO NOT MERGE THIS CHANGE INTO the 1.4 branch!!!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/20)
<!-- Reviewable:end -->
