### PR TITLE
Load Paratext projects even when first loading a multivoice script (HT-221)

### DIFF
--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -92,7 +92,8 @@ namespace HearThis
 			{
 				Settings.Default.Project = args[0];
 			}
-			else if (ParatextUtils.IsParatextInstalled)
+
+			if (ParatextUtils.IsParatextInstalled)
 			{
 				try
 				{


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/50)
<!-- Reviewable:end -->
