### PR TITLE
Show Overview when user selects that

### DIFF
--- a/src/HearThis/UI/ActorCharacterChooser.cs
+++ b/src/HearThis/UI/ActorCharacterChooser.cs
@@ -74,7 +74,7 @@ namespace HearThis.UI
 		void InitializeLists()
 		{
 			var actors = _actorCharacterProvider.Actors.ToArray();
-			_actorList.Items.Add(LocalizationManager.GetString("ActorCharacterChooser.Overview", "Overview", "Item appears at top of list of actors and means to show everything for all actors"));
+			_actorList.Items.Add(OverviewLabel);
 			var currentActor = _actorCharacterProvider.Actor;
 			bool gotSelection = false;
 			foreach (string actor in actors)
@@ -91,6 +91,8 @@ namespace HearThis.UI
 			if (!gotSelection)
 				_actorList.SelectedIndex = 0;
 		}
+
+		public static string OverviewLabel { get; } = LocalizationManager.GetString("ActorCharacterChooser.Overview", "Overview", "Item appears at top of list of actors and means to show everything for all actors");
 
 		private void ActorListOnSelectedValueChanged(object sender, EventArgs eventArgs)
 		{


### PR DESCRIPTION
???? remains at startup in overview mode
Large size of ???? is removed.
Fix temporary display of "Character" at startup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/60)
<!-- Reviewable:end -->
