### PR TITLE
HT 254: Migrate some settings from user settings to project-specific settings

### DIFF
--- a/src/HearThis/HearThis.csproj
+++ b/src/HearThis/HearThis.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Script\HearThisPackReader.cs" />
     <Compile Include="Script\IActorAssignmentsProvider.cs" />
     <Compile Include="Script\IBibleStats.cs" />
+    <Compile Include="Script\IScrProjectSettingsProvider.cs" />
     <Compile Include="Script\ISkippedStyleInfoProvider.cs" />
     <Compile Include="Script\IPublishingInfoProvider.cs" />
     <Compile Include="Script\MultiVoiceBlock.cs" />

--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -254,8 +254,6 @@ namespace HearThis
 		}
 		#endregion
 
-
-
 		#region HearThisAnonymousRegistrationInfo class
 		/// <summary>
 		/// Implementation of <see cref="RegistrationInfo"/> used to allow access to local Paratext projects when Paratext is not installed

--- a/src/HearThis/Properties/Settings.Designer.cs
+++ b/src/HearThis/Properties/Settings.Designer.cs
@@ -202,15 +202,6 @@ namespace HearThis.Properties {
             }
         }
         
-        [global::System.Configuration.ApplicationScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool ReplaceChevronsWithQuotes {
-            get {
-                return ((bool)(this["ReplaceChevronsWithQuotes"]));
-            }
-        }
-        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]

--- a/src/HearThis/Properties/Settings.Designer.cs
+++ b/src/HearThis/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace HearThis.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -202,15 +202,12 @@ namespace HearThis.Properties {
             }
         }
         
-        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool ReplaceChevronsWithQuotes {
             get {
                 return ((bool)(this["ReplaceChevronsWithQuotes"]));
-            }
-            set {
-                this["ReplaceChevronsWithQuotes"] = value;
             }
         }
         
@@ -345,7 +342,7 @@ namespace HearThis.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("2")]
+        [global::System.Configuration.DefaultSettingValueAttribute("3")]
         public int CurrentDataVersion {
             get {
                 return ((int)(this["CurrentDataVersion"]));

--- a/src/HearThis/Properties/Settings.settings
+++ b/src/HearThis/Properties/Settings.settings
@@ -47,7 +47,7 @@
     <Setting Name="BreakQuotesIntoBlocks" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="ReplaceChevronsWithQuotes" Type="System.Boolean" Scope="User">
+    <Setting Name="ReplaceChevronsWithQuotes" Type="System.Boolean" Scope="Application">
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="PublishAudioFormat" Type="System.String" Scope="User">
@@ -84,7 +84,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="CurrentDataVersion" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">2</Value>
+      <Value Profile="(Default)">3</Value>
     </Setting>
     <Setting Name="UserSpecifiedParatext8ProjectsDir" Type="System.String" Scope="User">
       <Value Profile="(Default)" />

--- a/src/HearThis/Properties/Settings.settings
+++ b/src/HearThis/Properties/Settings.settings
@@ -47,9 +47,6 @@
     <Setting Name="BreakQuotesIntoBlocks" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="ReplaceChevronsWithQuotes" Type="System.Boolean" Scope="Application">
-      <Value Profile="(Default)">True</Value>
-    </Setting>
     <Setting Name="PublishAudioFormat" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>

--- a/src/HearThis/Publishing/PublishDialog.cs
+++ b/src/HearThis/Publishing/PublishDialog.cs
@@ -50,15 +50,7 @@ namespace HearThis.Publishing
 			_scrProjectSettings = project.ScrProjectSettings;
 			_projectHasNestedQuotes = project.HasNestedQuotes;
 
-			var additionalBlockBreakCharacters = Settings.Default.AdditionalBlockBreakCharacters ?? string.Empty;
-			if (_scrProjectSettings != null && Settings.Default.BreakQuotesIntoBlocks && !String.IsNullOrEmpty(_scrProjectSettings.FirstLevelStartQuotationMark))
-			{
-				additionalBlockBreakCharacters += " " + _scrProjectSettings.FirstLevelStartQuotationMark;
-				if (_scrProjectSettings.FirstLevelStartQuotationMark != _scrProjectSettings.FirstLevelEndQuotationMark)
-					additionalBlockBreakCharacters += " " + _scrProjectSettings.FirstLevelEndQuotationMark;
-			}
-
-			_model = new PublishingModel(project, additionalBlockBreakCharacters);
+			_model = new PublishingModel(project);
 			_logBox.ShowDetailsMenuItem = true;
 			_logBox.ShowCopyToClipboardMenuItem = true;
 
@@ -264,15 +256,15 @@ namespace HearThis.Publishing
 
 		private void WarnAboutConflictBetweenQuoteBreakingAndSAB()
 		{
-			if (_includePhraseLevelLabels.Checked && _projectHasNestedQuotes && Settings.Default.BreakQuotesIntoBlocks &&
+			if (_includePhraseLevelLabels.Checked && _projectHasNestedQuotes && _model.PublishingInfoProvider.BreakQuotesIntoBlocks &&
 				_scrProjectSettings != null && !_scrProjectSettings.FirstLevelQuotesAreUnique)
 			{
 				var msg = string.Format(LocalizationManager.GetString("PublishDialog.PossibleIncompatibilityWithSAB",
 					"This project has first-level quotes broken out into separate blocks, but it looks like the first-level" +
 					" quotation marks may also be used for other levels (nested quotations). If you publish phrase-level labels," +
 					" Scripture App Builder will need to be configured to include the first-level quotation marks ({0} and {1})" +
-					" as phrase-ending punctuation, but Scripture App Builder might not be able to distinguish first-level quaotes" +
-					" (which should be considered as separate phrases) from other levels (which shoud not)." +
+					" as phrase-ending punctuation, but Scripture App Builder might not be able to distinguish first-level quotes" +
+					" (which should be considered as separate phrases) from other levels (which should not)." +
 					" Are you sure you want to publish phrase-level labels?", "Param 0 is first-level start quotation mark;" +
 					" Param 1 is first-level ending quotation mark"), _scrProjectSettings.FirstLevelStartQuotationMark,
 					_scrProjectSettings.FirstLevelEndQuotationMark);

--- a/src/HearThis/Publishing/PublishingModel.cs
+++ b/src/HearThis/Publishing/PublishingModel.cs
@@ -48,14 +48,10 @@ namespace HearThis.Publishing
 			_publishOnlyCurrentBook = Settings.Default.PublishCurrentBookOnly;
 		}
 
-		public PublishingModel(IPublishingInfoProvider infoProvider, string additionalBlockBreakCharacters) :
-			this(infoProvider.Name, infoProvider.EthnologueCode)
+		public PublishingModel(IPublishingInfoProvider infoProvider) : this(infoProvider.Name, infoProvider.EthnologueCode)
 		{
 			_infoProvider = infoProvider;
-			AdditionalBlockBreakCharacters = additionalBlockBreakCharacters;
 		}
-
-		private string AdditionalBlockBreakCharacters { get; set; }
 
 		internal bool PublishOnlyCurrentBook
 		{
@@ -104,10 +100,7 @@ namespace HearThis.Publishing
 		}
 
 
-		public IPublishingInfoProvider PublishingInfoProvider
-		{
-			get { return _infoProvider; }
-		}
+		public IPublishingInfoProvider PublishingInfoProvider => _infoProvider;
 
 		public bool IncludeBook(string bookName)
 		{
@@ -138,7 +131,8 @@ namespace HearThis.Publishing
 				if (AudioFormat == "scrAppBuilder" && VerseIndexFormat == VerseIndexFormatType.AudacityLabelFilePhraseLevel)
 				{
 					string msg;
-					if (string.IsNullOrWhiteSpace(AdditionalBlockBreakCharacters))
+					string additionalBlockBreakCharacters = _infoProvider.AdditionalBlockBreakCharacters; // I happen to know it's slightly more efficient to cache this.
+					if (String.IsNullOrEmpty(additionalBlockBreakCharacters))
 					{
 						msg = LocalizationManager.GetString("PublishDialog.ScriptureAppBuilderInstructionsNoAddlCharacters",
 							"When building the app using Scripture App Builder, make sure that the phrase-ending characters specified" +
@@ -149,7 +143,7 @@ namespace HearThis.Publishing
 						msg = String.Format(LocalizationManager.GetString("PublishDialog.ScriptureAppBuilderInstructionsNoAddlCharacters",
 							"When building the app using Scripture App Builder, make sure that the phrase-ending characters specified" +
 							" on the 'Features - Audio' page include the sentence-ending punctuation used in your project plus" +
-							" the following characters: {0}"), AdditionalBlockBreakCharacters);
+							" the following characters: {0}"), additionalBlockBreakCharacters);
 					}
 					progress.WriteMessage(""); // blank line
 					progress.WriteMessage(msg);

--- a/src/HearThis/Script/IPublishingInfoProvider.cs
+++ b/src/HearThis/Script/IPublishingInfoProvider.cs
@@ -20,5 +20,7 @@ namespace HearThis.Publishing
 		ScriptLine GetUnfilteredBlock(string bookName, int chapterNumber, int lineNumber0Based);
 		IBibleStats VersificationInfo { get; }
 		int BookNameComparer(string x, string y);
+		bool BreakQuotesIntoBlocks { get; }
+		string AdditionalBlockBreakCharacters { get; }
 	}
 }

--- a/src/HearThis/Script/IScrProjectSettingsProvider.cs
+++ b/src/HearThis/Script/IScrProjectSettingsProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace HearThis.Script
+{
+	interface IScrProjectSettingsProvider
+	{
+		IScrProjectSettings ScrProjectSettings { get; }
+	}
+}

--- a/src/HearThis/Script/MultiVoiceScriptProvider.cs
+++ b/src/HearThis/Script/MultiVoiceScriptProvider.cs
@@ -40,11 +40,11 @@ namespace HearThis.Script
 		public static BibleStats Stats = new BibleStats();
 
 		/// <summary>
-		///  This constructor takes the XML as a string (and is mainly used for testing)
+		///  This constructor takes the XML as a string (only used for testing)
 		/// </summary>
 		/// <param name="xmlInput"></param>
 		/// <param name="splitter"></param>
-		public MultiVoiceScriptProvider(string xmlInput, SentenceClauseSplitter splitter = null): this (XDocument.Parse(xmlInput), splitter)
+		internal MultiVoiceScriptProvider(string xmlInput, SentenceClauseSplitter splitter = null): this (XDocument.Parse(xmlInput), splitter)
 		{
 		}
 
@@ -58,17 +58,6 @@ namespace HearThis.Script
 		public MultiVoiceScriptProvider(XDocument script, SentenceClauseSplitter splitter = null)
 		{
 			_splitter = splitter;
-			if (_splitter == null)
-			{
-				char[] separators = null;
-				string additionalBreakCharacters = Settings.Default.AdditionalBlockBreakCharacters.Replace(" ", string.Empty);
-				if (additionalBreakCharacters.Length > 0)
-					separators = additionalBreakCharacters.ToArray();
-				// We never need to break at quotes with a glyssen script, since quotes are always a separate block already.
-				// The constructor needs a non-null value for scripture settings, but we don't actually use anything from it
-				// when breakAtFirstLevelQuotes is false, so we just pass an empty one.
-				_splitter = new SentenceClauseSplitter(separators, false, new GenericScriptureSettings());
-			}
 			_script = script;
 			var fileVersion = _script.Root.Attribute("version")?.Value??"1.0";
 			if (string.IsNullOrEmpty(fileVersion))
@@ -128,6 +117,20 @@ namespace HearThis.Script
 				}
 			}
 
+			Initialize(); // loads skip information and makes this the skip handler
+			// AFTER initialize, set splitter using project settings
+			if (_splitter == null)
+			{
+				char[] separators = null;
+				string additionalBreakCharacters = ProjectSettings.AdditionalBlockBreakCharacters.Replace(" ", string.Empty);
+				if (additionalBreakCharacters.Length > 0)
+					separators = additionalBreakCharacters.ToArray();
+				// We never need to break at quotes with a glyssen script, since quotes are always a separate block already.
+				// The constructor needs a non-null value for scripture settings, but we don't actually use anything from it
+				// when breakAtFirstLevelQuotes is false, so we just pass an empty one.
+				_splitter = new SentenceClauseSplitter(separators, false, new GenericScriptureSettings());
+			}
+
 			_bookElements = _script.Root.Element("script").Elements("book").ToArray();
 			_books = new Dictionary<int, MultiVoiceBook>();
 			foreach (var bookElt in _bookElements)
@@ -141,8 +144,8 @@ namespace HearThis.Script
 				.Distinct()
 				.Where(x => !string.IsNullOrEmpty(x))
 				.ToArray();
-			Initialize(); // loads skip information and makes this the skip handler
-			// AFTER initialize loads skip info, apply it to our lines.
+
+			// AFTER initialize and AFTER we have the content data, load skip info and apply it to our lines.
 			foreach (var book in _books.Values)
 			{
 				foreach (var chap in book.Chapters)

--- a/src/HearThis/Script/ParatextParagraph.cs
+++ b/src/HearThis/Script/ParatextParagraph.cs
@@ -51,12 +51,11 @@ namespace HearThis.Script
 
 		private string _verse = "0";
 
-		public ParatextParagraph(SentenceClauseSplitter splitter, bool replaceChevronsWithQuotes)
+		public ParatextParagraph(SentenceClauseSplitter splitter)
 		{
 			SentenceSplitter = splitter;
 			var settings = splitter.ScrProjSettings;
-			if (replaceChevronsWithQuotes &&
-				!string.IsNullOrEmpty(settings.FirstLevelStartQuotationMark) && "<<" != settings.FirstLevelStartQuotationMark &&
+			if (!string.IsNullOrEmpty(settings.FirstLevelStartQuotationMark) && "<<" != settings.FirstLevelStartQuotationMark &&
 				!string.IsNullOrEmpty(settings.FirstLevelEndQuotationMark) && ">>" != settings.FirstLevelEndQuotationMark)
 			{
 				 _quoteMarks = new List<QuoteMarkPair>(3);

--- a/src/HearThis/Script/ParatextScriptProvider.cs
+++ b/src/HearThis/Script/ParatextScriptProvider.cs
@@ -157,7 +157,7 @@ namespace HearThis.Script
 				state = _paratextProject.CreateScrParserState(verseRef);
 			}
 
-			var paragraph = new ParatextParagraph(_sentenceSplitter, Settings.Default.ReplaceChevronsWithQuotes) { DefaultFont = _paratextProject.DefaultFont, RightToLeft = _paratextProject.RightToLeft };
+			var paragraph = new ParatextParagraph(_sentenceSplitter) { DefaultFont = _paratextProject.DefaultFont, RightToLeft = _paratextProject.RightToLeft };
 			var versesPerChapter = GetArrayForVersesPerChapter(bookNumber0Based);
 
 			//Introductory lines, before the start of the chapter, will be in chapter 0

--- a/src/HearThis/Script/ParatextScriptProvider.cs
+++ b/src/HearThis/Script/ParatextScriptProvider.cs
@@ -19,7 +19,7 @@ using SIL.Scripture;
 
 namespace HearThis.Script
 {
-	public class ParatextScriptProvider : ScriptProviderBase
+	public class ParatextScriptProvider : ScriptProviderBase, IScrProjectSettingsProvider
 	{
 		private readonly IScripture _paratextProject;
 		private readonly Dictionary<int, Dictionary<int, List<ScriptLine>>> _script; // book <chapter, lines>
@@ -49,10 +49,10 @@ namespace HearThis.Script
 			Initialize();
 
 			char[] separators = null;
-			string additionalBreakCharacters = Settings.Default.AdditionalBlockBreakCharacters.Replace(" ", string.Empty);
-			if (additionalBreakCharacters.Length > 0)
+			string additionalBreakCharacters = ProjectSettings.AdditionalBlockBreakCharacters?.Replace(" ", string.Empty);
+			if (!String.IsNullOrEmpty(additionalBreakCharacters))
 				separators = additionalBreakCharacters.ToArray();
-			_sentenceSplitter = new SentenceClauseSplitter(separators, Settings.Default.BreakQuotesIntoBlocks, paratextProject);
+			_sentenceSplitter = new SentenceClauseSplitter(separators, ProjectSettings.BreakQuotesIntoBlocks, paratextProject);
 		}
 
 		public override string FontName

--- a/src/HearThis/Script/Project.cs
+++ b/src/HearThis/Script/Project.cs
@@ -177,6 +177,32 @@ namespace HearThis.Script
 				_scriptProvider.VersificationInfo.GetBookNumber(y));
 		}
 
+		public bool BreakQuotesIntoBlocks => ProjectSettings.BreakQuotesIntoBlocks;
+
+		/// <summary>
+		/// Note that this is NOT the same as ProjectSettings.AdditionalBlockBreakCharacters.
+		/// This property is implemented especially to support publishing and may include
+		/// additional characters not stored in the project setting by the same name.
+		/// </summary>
+		string IPublishingInfoProvider.AdditionalBlockBreakCharacters
+		{
+			get
+			{
+				var bldr = new StringBuilder(ProjectSettings.AdditionalBlockBreakCharacters);
+				var firstLevelStartQuotationMark = ScrProjectSettings?.FirstLevelStartQuotationMark;
+				if (BreakQuotesIntoBlocks && !String.IsNullOrEmpty(firstLevelStartQuotationMark))
+				{
+					if (bldr.Length > 0)
+						bldr.Append(" ");
+					bldr.Append(firstLevelStartQuotationMark);
+					var firstLevelEndQuotationMark = ScrProjectSettings.FirstLevelEndQuotationMark;
+					if (firstLevelStartQuotationMark != firstLevelEndQuotationMark)
+						bldr.Append(" ").Append(firstLevelEndQuotationMark);
+				}
+				return bldr.ToString();
+			}
+		}
+
 		public void GoToInitialChapter()
 		{
 			if (_selectedChapterInfo == null &&
@@ -243,8 +269,8 @@ namespace HearThis.Script
 		{
 			get
 			{
-				var paratextScriptProvider = _scriptProvider as ParatextScriptProvider;
-				return paratextScriptProvider == null ? null : paratextScriptProvider.ScrProjectSettings;
+				var paratextScriptProvider = _scriptProvider as IScrProjectSettingsProvider;
+				return paratextScriptProvider?.ScrProjectSettings;
 			}
 		}
 

--- a/src/HearThis/Script/ProjectSettings.cs
+++ b/src/HearThis/Script/ProjectSettings.cs
@@ -32,7 +32,7 @@ namespace HearThis.Script
 		/// getting settings for the very first time or 2) the settings were corrupted in a way that
 		/// prevented them from being deserialized. Note that in the latter case, we can't know for
 		/// sure which data migration steps need to be done because we don't know which version the
-		/// project was at when things went awry.  
+		/// project was at when things went awry.
 		/// </summary>
 		[XmlIgnore]
 		internal bool NewlyCreatedSettingsForExistingProject

--- a/src/HearThis/Script/ProjectSettings.cs
+++ b/src/HearThis/Script/ProjectSettings.cs
@@ -9,6 +9,7 @@
 // --------------------------------------------------------------------------------------------
 using System;
 using System.Xml.Serialization;
+using HearThis.Properties;
 
 namespace HearThis.Script
 {
@@ -16,10 +17,47 @@ namespace HearThis.Script
 	[XmlRoot(ElementName = "ProjectInfo", Namespace = "", IsNullable = false)]
 	public class ProjectSettings
 	{
+		private bool _newlyCreatedSettingsForExistingProject;
+
+		public ProjectSettings()
+		{
+			// Set default Clause-Break Characters
+			ClauseBreakCharacters = ", ; :";
+			Version = Settings.Default.CurrentDataVersion;
+		}
+
+		/// <summary>
+		/// This setting is not persisted, as it is only needed during data migration. It allows us to
+		/// correctly handle two edge cases: 1) a project from an early version of HearThis is
+		/// getting settings for the very first time or 2) the settings were corrupted in a way that
+		/// prevented them from being deserialized. Note that in the latter case, we can't know for
+		/// sure which data migration steps need to be done because we don't know which version the
+		/// project was at when things went awry.  
+		/// </summary>
+		[XmlIgnore]
+		internal bool NewlyCreatedSettingsForExistingProject
+		{
+			get => _newlyCreatedSettingsForExistingProject;
+			set
+			{
+				_newlyCreatedSettingsForExistingProject = value;
+				Version = 0;
+			}
+		}
+
 		[XmlAttribute("version")]
 		public int Version { get; set; }
 
 		[XmlAttribute("breakAtParagraphBreaks")]
 		public bool BreakAtParagraphBreaks { get; set; }
+
+		[XmlAttribute("breakQuotesIntoBlocks")]
+		public bool BreakQuotesIntoBlocks { get; set; }
+
+		[XmlAttribute("clauseBreakCharacters")]
+		public string ClauseBreakCharacters { get; set; }
+
+		[XmlAttribute("additionalBlockBreakCharacters")]
+		public string AdditionalBlockBreakCharacters { get; set; }
 	}
 }

--- a/src/HearThis/UI/AdministrativeSettings.cs
+++ b/src/HearThis/UI/AdministrativeSettings.cs
@@ -87,11 +87,11 @@ namespace HearThis.UI
 			}
 			else
 			{
-				_chkBreakAtQuotes.Checked = Settings.Default.BreakQuotesIntoBlocks;
+				_chkBreakAtQuotes.Checked = _project.ProjectSettings.BreakQuotesIntoBlocks;
 			}
-			_txtAdditionalBlockSeparators.Text = Settings.Default.AdditionalBlockBreakCharacters;
+			_txtAdditionalBlockSeparators.Text = _project.ProjectSettings.AdditionalBlockBreakCharacters;
 			_chkBreakAtParagraphBreaks.Checked = _project.ProjectSettings.BreakAtParagraphBreaks;
-			_txtClauseSeparatorCharacters.Text = Settings.Default.ClauseBreakCharacters;
+			_txtClauseSeparatorCharacters.Text = _project.ProjectSettings.ClauseBreakCharacters;
 			_lblWarningExistingRecordings.Visible = ClipRepository.GetDoAnyClipsExistForProject(project.Name);
 			_lblWarningExistingRecordings.ForeColor = _chkBreakAtQuotes.ForeColor;
 
@@ -122,25 +122,26 @@ namespace HearThis.UI
 				_project.SetSkippedStyle((string)_lbSkippedStyles.Items[i], _lbSkippedStyles.GetItemCheckState(i) == CheckState.Checked);
 
 			// Save settings on Punctuation tab
+			var projSettings = _project.ProjectSettings;
 			if (_chkBreakAtQuotes.Visible)
-				Settings.Default.BreakQuotesIntoBlocks = _chkBreakAtQuotes.Checked;
+				projSettings.BreakQuotesIntoBlocks = _chkBreakAtQuotes.Checked;
 			// Unfortunately, the Leave event doesn't get raised before the handling of the OK button click.
 			RemoveDuplicateSeparatorCharactersFromAIfTheyAreInB(
 				_txtAdditionalBlockSeparators.Focused ? _txtClauseSeparatorCharacters : _txtAdditionalBlockSeparators,
 				_txtAdditionalBlockSeparators.Focused ? _txtAdditionalBlockSeparators : _txtClauseSeparatorCharacters);
-			Settings.Default.AdditionalBlockBreakCharacters = _txtAdditionalBlockSeparators.Text.Replace("  ", " ").Trim();
-			Settings.Default.ClauseBreakCharacters = _txtClauseSeparatorCharacters.Text.Replace("  ", " ").Trim();
-			if (Settings.Default.BreakQuotesIntoBlocks || Settings.Default.AdditionalBlockBreakCharacters.Length > 0 ||
-				Settings.Default.ClauseBreakCharacters != ", ; :")
+			projSettings.AdditionalBlockBreakCharacters = _txtAdditionalBlockSeparators.Text.Replace("  ", " ").Trim();
+			projSettings.ClauseBreakCharacters = _txtClauseSeparatorCharacters.Text.Replace("  ", " ").Trim();
+			if (projSettings.BreakQuotesIntoBlocks || projSettings.AdditionalBlockBreakCharacters.Length > 0 ||
+				projSettings.ClauseBreakCharacters != ", ; :")
 			{
 				var details = new Dictionary<string, string>(1);
-				details["BreakQuotesIntoBlocks"] = Settings.Default.BreakQuotesIntoBlocks.ToString();
-				details["AdditionalBlockBreakCharacters"] = Settings.Default.AdditionalBlockBreakCharacters;
-				details["ClauseBreakCharacters"] = Settings.Default.ClauseBreakCharacters;
+				details["BreakQuotesIntoBlocks"] = projSettings.BreakQuotesIntoBlocks.ToString();
+				details["AdditionalBlockBreakCharacters"] = projSettings.AdditionalBlockBreakCharacters;
+				details["ClauseBreakCharacters"] = projSettings.ClauseBreakCharacters;
 				Analytics.Track("Punctuation settings changed", details);
 			}
 
-			_project.ProjectSettings.BreakAtParagraphBreaks = _chkBreakAtParagraphBreaks.Checked;
+			projSettings.BreakAtParagraphBreaks = _chkBreakAtParagraphBreaks.Checked;
 			_project.SaveProjectSettings();
 
 			// Save settings on Interface tab
@@ -231,9 +232,10 @@ namespace HearThis.UI
 
 		private void UpdateWarningTextColor(object sender, EventArgs e)
 		{
-			_lblWarningExistingRecordings.ForeColor = ((!_chkBreakAtQuotes.Visible || _chkBreakAtQuotes.Checked == Settings.Default.BreakQuotesIntoBlocks) &&
-				_txtAdditionalBlockSeparators.Text == Settings.Default.AdditionalBlockBreakCharacters &&
-				_chkBreakAtParagraphBreaks.Checked == _project.ProjectSettings.BreakAtParagraphBreaks) ?
+			var projSettings = _project.ProjectSettings;
+			_lblWarningExistingRecordings.ForeColor = ((!_chkBreakAtQuotes.Visible || _chkBreakAtQuotes.Checked == projSettings.BreakQuotesIntoBlocks) &&
+				_txtAdditionalBlockSeparators.Text == projSettings.AdditionalBlockBreakCharacters &&
+				_chkBreakAtParagraphBreaks.Checked == projSettings.BreakAtParagraphBreaks) ?
 				_chkBreakAtQuotes.ForeColor : AppPallette.Red;
 		}
 

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -261,6 +261,7 @@ namespace HearThis.UI
 
 			_project = project;
 			_scriptControl.SetFont(_project.FontName);
+			_scriptControl.SetClauseSeparators(_project.ProjectSettings.ClauseBreakCharacters);
 
 			_project.OnScriptBlockRecordingRestored += HandleScriptBlockRecordingRestored;
 
@@ -1071,6 +1072,11 @@ namespace HearThis.UI
 					OnSoundFileCreated(this, new EventArgs());
 				}
 			}
+		}
+
+		public void SetClauseSeparators(string clauseBreakCharacters)
+		{
+			_scriptControl.SetClauseSeparators(clauseBreakCharacters);
 		}
 	}
 }

--- a/src/HearThis/UI/ScriptControl.cs
+++ b/src/HearThis/UI/ScriptControl.cs
@@ -160,22 +160,10 @@ namespace HearThis.UI
 
 			internal static SentenceClauseSplitter ClauseSplitter;
 
-			static ScriptBlockPainter()
-			{
-				SetClauseSeparators();
-			}
-
-			public static void SetClauseSeparators()
-			{
-				string clauseSeparatorCharacters = Settings.Default.ClauseBreakCharacters.Replace(" ", string.Empty);
-				List<char> clauseSeparators = new List<char>(clauseSeparatorCharacters.ToCharArray());
-				clauseSeparators.Add(ScriptLine.kLineBreak);
-				ClauseSplitter = new SentenceClauseSplitter(clauseSeparators.ToArray());
-			}
-
 			public ScriptBlockPainter(ScriptControl control, Graphics graphics, ScriptLine script, RectangleF boundsF,
 				int mainFontSize, bool context)
 			{
+				ClauseSplitter = control.ClauseSplitter;
 				_context = context;
 				_script = script;
 
@@ -454,6 +442,18 @@ namespace HearThis.UI
 		public void SetFont(string name)
 		{
 			Font = new Font(name, 12F, FontStyle.Regular, GraphicsUnit.Point, ((byte)(0)));
+		}
+
+		internal SentenceClauseSplitter ClauseSplitter { get; private set;  }
+
+		public void SetClauseSeparators(string clauseBreakCharacters)
+		{
+			// Whenever a new project is set or the project's clause-break settings are changed, this should get called to set the
+			// clause break characters stored in the project settings.
+			string clauseSeparatorCharacters = (clauseBreakCharacters ?? Settings.Default.ClauseBreakCharacters).Replace(" ", string.Empty);
+			List<char> clauseSeparators = new List<char>(clauseSeparatorCharacters.ToCharArray());
+			clauseSeparators.Add(ScriptLine.kLineBreak);
+			ClauseSplitter = new SentenceClauseSplitter(clauseSeparators.ToArray());
 		}
 
 		public enum Direction

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -289,9 +289,9 @@ namespace HearThis.UI
 
 		private void OnSettingsButtonClicked(object sender, EventArgs e)
 		{
-			var origBreakQuotesIntoBlocksValue = Settings.Default.BreakQuotesIntoBlocks;
-			var origAdditionalBlockBreakChars = Settings.Default.AdditionalBlockBreakCharacters;
-			var origBreakAtParagraphBreaks = Project?.ProjectSettings?.BreakAtParagraphBreaks;
+			var origBreakQuotesIntoBlocksValue = Project.ProjectSettings.BreakQuotesIntoBlocks;
+			var origAdditionalBlockBreakChars = Project.ProjectSettings.AdditionalBlockBreakCharacters;
+			var origBreakAtParagraphBreaks = Project.ProjectSettings.BreakAtParagraphBreaks;
 			DialogResult result = _settingsProtectionHelper.LaunchSettingsIfAppropriate(() =>
 			{
 				using (var dlg = new AdministrativeSettings(Project))
@@ -301,15 +301,15 @@ namespace HearThis.UI
 			});
 			if (result == DialogResult.OK)
 			{
-				if (origBreakQuotesIntoBlocksValue != Settings.Default.BreakQuotesIntoBlocks ||
-					origAdditionalBlockBreakChars != Settings.Default.AdditionalBlockBreakCharacters ||
-					origBreakAtParagraphBreaks != Project?.ProjectSettings?.BreakAtParagraphBreaks)
+				if (origBreakQuotesIntoBlocksValue != Project.ProjectSettings.BreakQuotesIntoBlocks ||
+					origAdditionalBlockBreakChars != Project.ProjectSettings.AdditionalBlockBreakCharacters ||
+					origBreakAtParagraphBreaks != Project.ProjectSettings.BreakAtParagraphBreaks)
 				{
 					LoadProject(Settings.Default.Project);
 				}
 				else
 				{
-					ScriptControl.ScriptBlockPainter.SetClauseSeparators();
+					_recordingToolControl1.SetClauseSeparators(Project.ProjectSettings.ClauseBreakCharacters);
 #if MULTIPLEMODES
 					Invoke(new Action(InitializeModesCombo));
 #else

--- a/src/HearThis/app.config
+++ b/src/HearThis/app.config
@@ -4,9 +4,6 @@
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="HearThis.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
-        <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="HearThis.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-        </sectionGroup>
     </configSections>
     <userSettings>
         <HearThis.Properties.Settings>
@@ -121,11 +118,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-  <applicationSettings>
-    <HearThis.Properties.Settings>
-      <setting name="ReplaceChevronsWithQuotes" serializeAs="String">
-        <value>True</value>
-      </setting>
-    </HearThis.Properties.Settings>
-  </applicationSettings>
 </configuration>

--- a/src/HearThis/app.config
+++ b/src/HearThis/app.config
@@ -4,6 +4,9 @@
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="HearThis.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
+        <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="HearThis.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+        </sectionGroup>
     </configSections>
     <userSettings>
         <HearThis.Properties.Settings>
@@ -49,9 +52,6 @@
             <setting name="BreakQuotesIntoBlocks" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="ReplaceChevronsWithQuotes" serializeAs="String">
-                <value>True</value>
-            </setting>
             <setting name="PublishAudioFormat" serializeAs="String">
                 <value />
             </setting>
@@ -77,19 +77,19 @@
                 <value>1</value>
             </setting>
             <setting name="CurrentDataVersion" serializeAs="String">
-                <value>2</value>
+                <value>3</value>
             </setting>
             <setting name="UserSpecifiedParatext8ProjectsDir" serializeAs="String">
                 <value />
-            </setting>
-            <setting name="UserColorScheme" serializeAs="String">
-                <value>Normal</value>
             </setting>
             <setting name="Actor" serializeAs="String">
                 <value />
             </setting>
             <setting name="Character" serializeAs="String">
                 <value />
+            </setting>
+            <setting name="UserColorScheme" serializeAs="String">
+                <value>Normal</value>
             </setting>
         </HearThis.Properties.Settings>
     </userSettings>
@@ -121,4 +121,11 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <applicationSettings>
+    <HearThis.Properties.Settings>
+      <setting name="ReplaceChevronsWithQuotes" serializeAs="String">
+        <value>True</value>
+      </setting>
+    </HearThis.Properties.Settings>
+  </applicationSettings>
 </configuration>

--- a/src/HearThisTests/ClipRepositoryTests.cs
+++ b/src/HearThisTests/ClipRepositoryTests.cs
@@ -16,7 +16,7 @@ namespace HearThisTests
 
 		private class TestPublishingModel : PublishingModel
 		{
-			public TestPublishingModel(VerseIndexFormatType verseIndexFormat) : base(new DummyInfoProvider(), null)
+			public TestPublishingModel(VerseIndexFormatType verseIndexFormat) : base(new DummyInfoProvider())
 			{
 				AudioFormat = "megaVoice";
 				VerseIndexFormat = verseIndexFormat;
@@ -100,6 +100,9 @@ namespace HearThisTests
 			{
 				return 0;
 			}
+
+			public bool BreakQuotesIntoBlocks => false;
+			public string AdditionalBlockBreakCharacters => null;
 		}
 
 		/// <summary>
@@ -148,7 +151,7 @@ namespace HearThisTests
 		{
 			var publishingInfoProvider = new DummyInfoProvider();
 			var projectName = publishingInfoProvider.Name;
-			var publishingModel = new PublishingModel(publishingInfoProvider, null);
+			var publishingModel = new PublishingModel(publishingInfoProvider);
 			publishingModel.AudioFormat = "megaVoice";
 			publishingModel.PublishOnlyCurrentBook = false;
 			publishingInfoProvider.BooksNotToPublish.Add("Proverbs");
@@ -192,7 +195,7 @@ namespace HearThisTests
 			publishingInfoProvider.Strict = true;
 			publishingInfoProvider.CurrentBookName = "Philemon";
 			var projectName = publishingInfoProvider.Name;
-			var publishingModel = new PublishingModel(publishingInfoProvider, null);
+			var publishingModel = new PublishingModel(publishingInfoProvider);
 			publishingModel.AudioFormat = "megaVoice";
 			publishingModel.PublishOnlyCurrentBook = true;
 			using (var mono = TempFile.FromResource(Resource1._1Channel, ".wav"))

--- a/src/HearThisTests/ParatextParagraphTests.cs
+++ b/src/HearThisTests/ParatextParagraphTests.cs
@@ -11,7 +11,7 @@ namespace HearThisTests
 		[Test]
 		public void NewInstance_HasNoText()
 		{
-			Assert.That(new ParatextParagraph(_splitter, true).HasData, Is.False);
+			Assert.That(new ParatextParagraph(_splitter).HasData, Is.False);
 		}
 
 		[Test]
@@ -19,7 +19,7 @@ namespace HearThisTests
 		{
 			var stateStub = new ParserStateStub();
 			stateStub.ParaTag = new ScrTag();
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			pp.StartNewParagraph(stateStub, true);
 			Assert.That(pp.HasData, Is.False);
 			pp.Add("this is text");
@@ -29,7 +29,7 @@ namespace HearThisTests
 		[Test]
 		public void AddingEmptyString_LeavesHasDataFalse()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			Assert.That(pp.HasData, Is.False);
 			pp.Add("");
@@ -39,7 +39,7 @@ namespace HearThisTests
 		[Test]
 		public void AddingWhitespaceString_LeavesHasDataFalse()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			Assert.That(pp.HasData, Is.False);
 			pp.Add("        ");
@@ -50,7 +50,7 @@ namespace HearThisTests
 		public void Add_ReplaceChevronsWithQuotesWhenQuotesAreChevrons_NoChevronReplacementPerformed()
 		{
 			var splitter = new SentenceClauseSplitter(null, true, new ChevronQuotesProject());
-			var pp = new ParatextParagraph(splitter, true);
+			var pp = new ParatextParagraph(splitter);
 			SetDefaultState(pp);
 			pp.Add("Then God said, <<Do not say, <Why did the Lord say, <<You have sinned,>> when we did what was right in our own eyes,> or I will pluck you from this good land.>>");
 			var result = pp.BreakIntoBlocks().ToArray();
@@ -62,7 +62,7 @@ namespace HearThisTests
 		[Test]
 		public void StartingParagraph_ClearsText()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("this is text");
 			Assert.That(pp.BreakIntoBlocks().First().Text, Is.EqualTo("this is text")); // This prevents debug assertion failure.
@@ -73,7 +73,7 @@ namespace HearThisTests
 		[Test]
 		public void BlocksTakeFontInfoFromState()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			var stateStub = new ParserStateStub();
 			stateStub.ParaTag = new ScrTag {Marker = @"\s", Name = "Section Head", Bold = true,
 				JustificationType = ScrJustificationType.scCenter, FontSize = 49, Fontname = "myfont",
@@ -95,7 +95,7 @@ namespace HearThisTests
 		[Test]
 		public void BlocksTakeFontInfoFromDefaultIfStateBlank()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			pp.DefaultFont = "SomeFont";
 			var stateStub = new ParserStateStub();
 			stateStub.ParaTag = new ScrTag()
@@ -124,7 +124,7 @@ namespace HearThisTests
 		[Test]
 		public void LineNumberContinuesIncreasingIfNotReset()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			pp.DefaultFont = "SomeFont";
 			var stateStub = SetDefaultState(pp);
 			pp.Add("This is text. So is This.");
@@ -148,7 +148,7 @@ namespace HearThisTests
 		[Test]
 		public void InputWithNoSeparators_YieldsOneLine()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("this is text");
 			var blocks = pp.BreakIntoBlocks().ToList();
@@ -159,7 +159,7 @@ namespace HearThisTests
 		[Test]
 		public void InputWithCommonSeparators_YieldsMultipleLines_WithCorrectPunctuation()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("this is text; this is more. Is this good text? You decide! It makes a test, anyway.");
 			var blocks = pp.BreakIntoBlocks().ToList();
@@ -173,7 +173,7 @@ namespace HearThisTests
 		[Test]
 		public void BreakIntoBlocks_TwoSentencesWithinSingleVerse_YieldsTwoBlocksWithSameVerseNumber()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.NoteVerseStart("2");
 			pp.Add("Verse two.");
@@ -196,7 +196,7 @@ namespace HearThisTests
 		[Test]
 		public void BreakIntoBlocks_SentencesCrossVerseBreaks_YieldsBlocksWithImplicitVerseBridge()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.NoteVerseStart("2");
 			const string kV2Text = "If some people don't believe; ";
@@ -228,7 +228,7 @@ namespace HearThisTests
 		[Test]
 		public void BreakIntoBlocks_DeeplyNestedChevrons_YieldsBlocksWithCorrectVerseNumber()
 		{
-			var pp = new ParatextParagraph(new SentenceClauseSplitter(null, true, new CurlyQuotesProject()), true);
+			var pp = new ParatextParagraph(new SentenceClauseSplitter(null, true, new CurlyQuotesProject()));
 			SetDefaultState(pp);
 			pp.NoteVerseStart("9");
 			pp.Add("<<You are a <martian>,>> noted John. ");
@@ -249,7 +249,7 @@ namespace HearThisTests
 		[Test]
 		public void BreakIntoBlocks_SentenceBeginsInVerseFollowingEmptyVerse_YieldsBlocksWithCorrectVerseNumber()
 		{
-			var pp = new ParatextParagraph(new SentenceClauseSplitter(null, true, new CurlyQuotesProject()), true);
+			var pp = new ParatextParagraph(new SentenceClauseSplitter(null, true, new CurlyQuotesProject()));
 			SetDefaultState(pp);
 			pp.NoteVerseStart("9");
 			pp.Add("<<You are a martian,>> noted John. ");
@@ -275,7 +275,7 @@ namespace HearThisTests
 		[Test]
 		public void BreakIntoBlocks_DevenagriInput_SeparatesCorrectly()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add(
 				"विराम अवस्था में किसी वस्तु की ऊर्जा का मान mc2 होता है जहां m वस्तु का द्रव्यमान है। ऊर्जा सरंक्षण के नियम से किसी भी क्रिया में द्रव्यमान में कमी क्रिया के पश्चात इसकी गतिज ऊर्जा में वृद्धि के तुल्य होनी चाहिए। इसी प्रकार, किसी वस्तु का द्रव्यमान को इसकी गतिज ऊर्जा को इसमें लेकर बढाया जा सकता है।");
@@ -291,7 +291,7 @@ namespace HearThisTests
 		[Test]
 		public void InputWithAngleBrackets_YieldsProperQuotes()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("He said, <<Is this good text?>> She said, <<I'm not sure. >> “You decide”! It makes a <<test>>, anyway");
 			var blocks = pp.BreakIntoBlocks().ToList();
@@ -305,7 +305,7 @@ namespace HearThisTests
 		[Test]
 		public void InputWithAngleBrackets_YieldsProperQuotes_ForSingleSentence()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("He said, <<This is good text>>");
 			var blocks = pp.BreakIntoBlocks().ToList();
@@ -316,7 +316,7 @@ namespace HearThisTests
 		[Test]
 		public void InputWithFinalClosingQuoteAfterPunctuation()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("He said, <<This is good text!>>");
 			var blocks = pp.BreakIntoBlocks().ToList();
@@ -327,7 +327,7 @@ namespace HearThisTests
 		[Test]
 		public void SingleClosingQuoteGoesToPreviousSegment()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("He said, <This is good text!> <Here is some more>");
 			var blocks = pp.BreakIntoBlocks().ToList();
@@ -340,7 +340,7 @@ namespace HearThisTests
 		public void TripleAngleBracketsHandledCorrectly()
 		{
 			// This is really essentially a test of the SentenceClauseSplitter class
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("He said, <<She said, <This is good text!>>> <<<Here is some more!> she said.>>");
 			var blocks = pp.BreakIntoBlocks().ToList();
@@ -356,7 +356,7 @@ namespace HearThisTests
 		[Test]
 		public void ClosingQuoteSpaceCombination_AttachesToPreviousSentence()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("He said, «She said, <This is good text!>  › ”» «Here is some more!» Bill said.");
 			var blocks = pp.BreakIntoBlocks().ToList();
@@ -369,7 +369,7 @@ namespace HearThisTests
 		[Test]
 		public void ClosingQuoteAndParen_AttachesToPreviousSentence()
 		{
-			var pp = new ParatextParagraph(_splitter, false);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("He said, «She said, (This is good text!)  › ”» [Here is some more! ] Bill said.");
 			var blocks = pp.BreakIntoBlocks().ToList();
@@ -382,7 +382,7 @@ namespace HearThisTests
 		[Test]
 		public void LeadingQuestionMarkDoesNotPreventSegmentation()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("?Hello? This is a sentence. This is another.");
 			var blocks = pp.BreakIntoBlocks().ToList();
@@ -395,7 +395,7 @@ namespace HearThisTests
 		[Test]
 		public void LeadingSegBreakInLaterSegment_GetsAttachedToFollowing()
 		{
-			var pp = new ParatextParagraph(_splitter, true);
+			var pp = new ParatextParagraph(_splitter);
 			SetDefaultState(pp);
 			pp.Add("This is a test. !This is emphasised! This is another.");
 			var blocks = pp.BreakIntoBlocks().ToList();

--- a/src/HearThisTests/ProjectTests.cs
+++ b/src/HearThisTests/ProjectTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using HearThis.Publishing;
 using HearThis.Script;
 using NUnit.Framework;
 
@@ -21,15 +22,87 @@ namespace HearThisTests
 			var infoContent = project.GetProjectRecordingStatusInfoFileContent();
 			Assert.That(infoContent, Is.EqualTo("Genesis;" + Environment.NewLine + "Matthew;1:0,3:2,7:3,2:2" + Environment.NewLine));
 		}
+
+		[TestCase(null)]
+		[TestCase("")]
+		public void GetIPublishingInfoProvider_AdditionalBlockBreakCharacters_NoAdditionalCharacters_ReturnsNullOrEmpty(string additionalBreakChars)
+		{
+			var fakeScriptProvider = new TestScriptProvider(new ChevronQuotesProject());
+			var project = new Project(fakeScriptProvider);
+			project.ProjectSettings.AdditionalBlockBreakCharacters = additionalBreakChars;
+			project.ProjectSettings.BreakQuotesIntoBlocks = false;
+			Assert.That(String.IsNullOrEmpty(((IPublishingInfoProvider)project).AdditionalBlockBreakCharacters));
+		}
+
+		[Test]
+		public void GetIPublishingInfoProvider_AdditionalBlockBreakCharacters_OnlyExplicitAdditionalCharacters_ReturnsExplicitAdditionalBreakCharacters()
+		{
+			var fakeScriptProvider = new TestScriptProvider(new ChevronQuotesProject());
+			var project = new Project(fakeScriptProvider);
+			project.ProjectSettings.AdditionalBlockBreakCharacters = "^ + @";
+			project.ProjectSettings.BreakQuotesIntoBlocks = false;
+			Assert.AreEqual("^ + @", ((IPublishingInfoProvider)project).AdditionalBlockBreakCharacters);
+		}
+
+		[Test]
+		public void GetIPublishingInfoProvider_AdditionalBlockBreakCharacters_ExplicitAdditionalCharactersQuoteBreakWithSameStartAndEndQuote_ReturnsExplicitAdditionalBreakCharactersPlusStartQuote()
+		{
+			var fakeScriptProvider = new TestScriptProvider(new StraightQuotesProject());
+			var project = new Project(fakeScriptProvider);
+			project.ProjectSettings.AdditionalBlockBreakCharacters = ";";
+			project.ProjectSettings.BreakQuotesIntoBlocks = true;
+			Assert.AreEqual("; \"", ((IPublishingInfoProvider)project).AdditionalBlockBreakCharacters);
+		}
+
+		[TestCase(null)]
+		[TestCase("")]
+		public void GetIPublishingInfoProvider_AdditionalBlockBreakCharacters_NoExplicitAdditionalCharactersQuoteBreakWithSameStartAndEndQuote_ReturnsOnlyStartQuote(string additionalBreakChars)
+		{
+			var fakeScriptProvider = new TestScriptProvider(new StraightQuotesProject());
+			var project = new Project(fakeScriptProvider);
+			project.ProjectSettings.AdditionalBlockBreakCharacters = additionalBreakChars;
+			project.ProjectSettings.BreakQuotesIntoBlocks = true;
+			Assert.AreEqual("\"", ((IPublishingInfoProvider)project).AdditionalBlockBreakCharacters);
+		}
+
+		[Test]
+		public void GetIPublishingInfoProvider_AdditionalBlockBreakCharacters_ExplicitAdditionalCharactersQuoteBreakWithDifferentStartAndEndQuote_ReturnsExplicitAdditionalBreakCharactersPlusStartAndEndQuotes()
+		{
+			var fakeScriptProvider = new TestScriptProvider(new ChevronQuotesProject());
+			var project = new Project(fakeScriptProvider);
+			project.ProjectSettings.AdditionalBlockBreakCharacters = ";";
+			project.ProjectSettings.BreakQuotesIntoBlocks = true;
+			Assert.AreEqual("; << >>", ((IPublishingInfoProvider)project).AdditionalBlockBreakCharacters);
+		}
+
+		[TestCase(null)]
+		[TestCase("")]
+		public void GetIPublishingInfoProvider_AdditionalBlockBreakCharacters_NoExplicitAdditionalCharactersQuoteBreakWithDifferentStartAndEndQuote_ReturnsOnlyStartAndEndQuotes(string additionalBreakChars)
+		{
+			var fakeScriptProvider = new TestScriptProvider(new CurlyQuotesProject());
+			var project = new Project(fakeScriptProvider);
+			project.ProjectSettings.AdditionalBlockBreakCharacters = additionalBreakChars;
+			project.ProjectSettings.BreakQuotesIntoBlocks = true;
+			Assert.AreEqual("“ ”", ((IPublishingInfoProvider)project).AdditionalBlockBreakCharacters);
+		}
 	}
 
-	class TestScriptProvider : ScriptProviderBase
+	class TestScriptProvider : ScriptProviderBase, IScrProjectSettingsProvider
 	{
-		private FakeVerseInfo _verseInfo;
+		private readonly FakeVerseInfo _verseInfo;
+
 		public TestScriptProvider()
 		{
 			_verseInfo = new FakeVerseInfo();
 		}
+
+		public TestScriptProvider(IScrProjectSettings scrProjectSettings = null)
+		{
+			ScrProjectSettings = scrProjectSettings;
+			_verseInfo = new FakeVerseInfo();
+			Initialize();
+		}
+
 		public override ScriptLine GetBlock(int bookNumber, int chapterNumber, int lineNumber0Based)
 		{
 			throw new NotImplementedException();
@@ -100,6 +173,8 @@ namespace HearThisTests
 		{
 			get { return _verseInfo; }
 		}
+
+		public IScrProjectSettings ScrProjectSettings { get; }
 	}
 
 	class FakeVerseInfo : IBibleStats
@@ -135,5 +210,16 @@ namespace HearThisTests
 		{
 			return chapCounts[bookNumber0Based];
 		}
+	}
+
+	internal class StraightQuotesProject : IScrProjectSettings
+	{
+		public string FirstLevelStartQuotationMark => "\"";
+		public string FirstLevelEndQuotationMark => "\"";
+		public string SecondLevelStartQuotationMark => "'";
+		public string SecondLevelEndQuotationMark => "'";
+		public string ThirdLevelStartQuotationMark => "\"";
+		public string ThirdLevelEndQuotationMark => "\"";
+		public bool FirstLevelQuotesAreUnique => false;
 	}
 }

--- a/src/HearThisTests/SentenceClauseSplitterTests.cs
+++ b/src/HearThisTests/SentenceClauseSplitterTests.cs
@@ -137,7 +137,7 @@ namespace HearThisTests
 				splitter.BreakIntoChunks(textToBreak).ToList();
 			stopwatch.Stop();
 			Debug.WriteLine("Elapsed milliseconds: " + stopwatch.ElapsedMilliseconds);
-			Assert.IsTrue(stopwatch.ElapsedMilliseconds < 30);
+			Assert.Less(stopwatch.ElapsedMilliseconds, 30);
 		}
 	}
 


### PR DESCRIPTION
BreakQuotesIntoBlocks, ClauseBreakCharacters, AdditionalBlockBreakCharacters
Also fixed a couple minor typos and handled cleanly the (unlikely and as yet never encountered, AFAIK) case where a project settings file has become corrupted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/93)
<!-- Reviewable:end -->
