### PR TITLE
HT-260: Fix index out-of-range crash when replacing chevrons with quotes

### DIFF
--- a/src/HearThis/Script/ParatextParagraph.cs
+++ b/src/HearThis/Script/ParatextParagraph.cs
@@ -192,11 +192,10 @@ namespace HearThis.Script
 		{
 			if (_quoteMarks == null)
 				return;
-			// Common (?) way of representing quotes in Paratext. The >>> combination is special to avoid getting the double first;
-			// <<< is not special as the first two are correctly changed to double quote, then the third to single.
-			// It is, of course, important to do all the double replacements before the single, otherwise, the single will just match doubles twice.
-			// ENHANCE: Make more efficient.
-			// ENHANCE: The >>> trick doesn't always work right. You need to know how deeply nested you are.
+			// Greater-than (>) and less-than (<) symbols are sometimes used as "chevrons" to indicate
+			// the start and end of quotes in Paratext. When nested, this can yield text that is not very
+			// human-readble, e.g. <<< or >>>. This code used to be done using efficient regular expression
+			// replacements, but it did not correctly handle the possibility of deeply nested quotes.
 			for (int i = startAt; i < _text.Length; i++)
 			{
 				char ch = _text[i];
@@ -216,8 +215,12 @@ namespace HearThis.Script
 					if (_quoteMarks.Count > 1)
 					{
 						_text.Remove(i, 1);
-						if (quoteDepth % 2 == 0) // We were looking for level 1 quote, but found level 2 instead, so just jump ahead
+						if (quoteDepth % 2 == 0)
+						{
+							// We were looking for an even level quote (i.e., double chevron), but found an odd level
+							// (single chevron) instead, so we do an extra increment of the level to jump ahead.
 							quoteDepth++;
+						}
 						_text.Insert(i, _quoteMarks[quoteDepth++ % _quoteMarks.Count].Start);
 					}
 					else

--- a/src/HearThis/Script/ParatextParagraph.cs
+++ b/src/HearThis/Script/ParatextParagraph.cs
@@ -192,7 +192,7 @@ namespace HearThis.Script
 		{
 			if (_quoteMarks == null)
 				return;
-			// Common way of representing quotes in Paratext. The >>> combination is special to avoid getting the double first;
+			// Common (?) way of representing quotes in Paratext. The >>> combination is special to avoid getting the double first;
 			// <<< is not special as the first two are correctly changed to double quote, then the third to single.
 			// It is, of course, important to do all the double replacements before the single, otherwise, the single will just match doubles twice.
 			// ENHANCE: Make more efficient.
@@ -213,10 +213,15 @@ namespace HearThis.Script
 						}
 					}
 					// Found an opening single chevron
-					_text.Remove(i, 1);
-					if (quoteDepth % 2 == 0) // We were looking for level 1 quote, but found level 2 instead, so just jump ahead
+					if (_quoteMarks.Count > 1)
+					{
+						_text.Remove(i, 1);
+						if (quoteDepth % 2 == 0) // We were looking for level 1 quote, but found level 2 instead, so just jump ahead
+							quoteDepth++;
+						_text.Insert(i, _quoteMarks[quoteDepth++ % _quoteMarks.Count].Start);
+					}
+					else
 						quoteDepth++;
-					_text.Insert(i, _quoteMarks[quoteDepth++ % _quoteMarks.Count].Start);
 				}
 				else if (ch == '>' && quoteDepth > 0)
 				{
@@ -229,12 +234,14 @@ namespace HearThis.Script
 							_text.Insert(i, _quoteMarks[--quoteDepth % _quoteMarks.Count].End);
 						}
 					}
-					else
+					else if (_quoteMarks.Count > 1)
 					{
 						// Found a closing single chevron
 						_text.Remove(i, 1);
 						_text.Insert(i, _quoteMarks[--quoteDepth % _quoteMarks.Count].End);
 					}
+					else
+						quoteDepth--;
 				}
 			}
 		}

--- a/src/HearThis/Script/ParatextParagraph.cs
+++ b/src/HearThis/Script/ParatextParagraph.cs
@@ -208,7 +208,7 @@ namespace HearThis.Script
 						if (i + 1 < _text.Length && _text[i + 1] == '<')
 						{
 							_text.Remove(i, 2);
-							_text.Insert(i, _quoteMarks[quoteDepth++ % 3].Start);
+							_text.Insert(i, _quoteMarks[quoteDepth++ % _quoteMarks.Count].Start);
 							continue;
 						}
 					}
@@ -216,7 +216,7 @@ namespace HearThis.Script
 					_text.Remove(i, 1);
 					if (quoteDepth % 2 == 0) // We were looking for level 1 quote, but found level 2 instead, so just jump ahead
 						quoteDepth++;
-					_text.Insert(i, _quoteMarks[quoteDepth++ % 3].Start);
+					_text.Insert(i, _quoteMarks[quoteDepth++ % _quoteMarks.Count].Start);
 				}
 				else if (ch == '>' && quoteDepth > 0)
 				{
@@ -226,14 +226,14 @@ namespace HearThis.Script
 						if (i + 1 < _text.Length && _text[i + 1] == '>')
 						{
 							_text.Remove(i, 2);
-							_text.Insert(i, _quoteMarks[--quoteDepth % 3].End);
+							_text.Insert(i, _quoteMarks[--quoteDepth % _quoteMarks.Count].End);
 						}
 					}
 					else
 					{
 						// Found a closing single chevron
 						_text.Remove(i, 1);
-						_text.Insert(i, _quoteMarks[--quoteDepth % 3].End);
+						_text.Insert(i, _quoteMarks[--quoteDepth % _quoteMarks.Count].End);
 					}
 				}
 			}

--- a/src/HearThisTests/ParatextParagraphTests.cs
+++ b/src/HearThisTests/ParatextParagraphTests.cs
@@ -247,6 +247,48 @@ namespace HearThisTests
 		}
 
 		[Test]
+		public void BreakIntoBlocks_NestedChevronsInTextButOnlyTwoLevelsOfQuotesDefinedInProject_NestedChevronsConvertedCorrectly()
+		{
+			var pp = new ParatextParagraph(new SentenceClauseSplitter(null, true, new TwoLevelCurlyQuotesProject()));
+			SetDefaultState(pp);
+			pp.NoteVerseStart("9");
+			pp.Add("<<You are a <martian>,>> noted John. ");
+			pp.NoteVerseStart("10");
+			pp.Add("<<You say, <You are a <<martian,>>> but I think you are from Pluto!>> rebutted his friend Wally.");
+			var blocks = pp.BreakIntoBlocks().ToList();
+			Assert.That(blocks, Has.Count.EqualTo(4));
+			Assert.That(blocks[0].Text, Is.EqualTo("“You are a ‘martian’,”"));
+			Assert.That(blocks[0].Verse, Is.EqualTo("9"));
+			Assert.That(blocks[1].Text, Is.EqualTo("noted John."));
+			Assert.That(blocks[1].Verse, Is.EqualTo("9"));
+			Assert.That(blocks[2].Text, Is.EqualTo("“You say, ‘You are a “martian,”’ but I think you are from Pluto!”"));
+			Assert.That(blocks[2].Verse, Is.EqualTo("10"));
+			Assert.That(blocks[3].Text, Is.EqualTo("rebutted his friend Wally."));
+			Assert.That(blocks[3].Verse, Is.EqualTo("10"));
+		}
+
+		[Test]
+		public void BreakIntoBlocks_SingleClosingChevronInTextButOnlyOneLevelOfQuotesDefinedInProject_SingleChevronsNotConverted()
+		{
+			var pp = new ParatextParagraph(new SentenceClauseSplitter(null, true, new OneLevelCurlyQuotesProject()));
+			SetDefaultState(pp);
+			pp.NoteVerseStart("9");
+			pp.Add("<<You are a <martian>,>> noted John. ");
+			pp.NoteVerseStart("10");
+			pp.Add("<<You say, <You are a <<martian,>>> but I think you are from Pluto!>> rebutted his friend Wally.");
+			var blocks = pp.BreakIntoBlocks().ToList();
+			Assert.That(blocks, Has.Count.EqualTo(4));
+			Assert.That(blocks[0].Text, Is.EqualTo("“You are a <martian>,”"));
+			Assert.That(blocks[0].Verse, Is.EqualTo("9"));
+			Assert.That(blocks[1].Text, Is.EqualTo("noted John."));
+			Assert.That(blocks[1].Verse, Is.EqualTo("9"));
+			Assert.That(blocks[2].Text, Is.EqualTo("“You say, <You are a “martian,”> but I think you are from Pluto!”"));
+			Assert.That(blocks[2].Verse, Is.EqualTo("10"));
+			Assert.That(blocks[3].Text, Is.EqualTo("rebutted his friend Wally."));
+			Assert.That(blocks[3].Verse, Is.EqualTo("10"));
+		}
+
+		[Test]
 		public void BreakIntoBlocks_SentenceBeginsInVerseFollowingEmptyVerse_YieldsBlocksWithCorrectVerseNumber()
 		{
 			var pp = new ParatextParagraph(new SentenceClauseSplitter(null, true, new CurlyQuotesProject()));
@@ -404,5 +446,27 @@ namespace HearThisTests
 			Assert.That(blocks[1].Text, Is.EqualTo("!This is emphasised!"));
 			Assert.That(blocks[2].Text, Is.EqualTo("This is another."));
 		}
+	}
+
+	internal class OneLevelCurlyQuotesProject : IScrProjectSettings
+	{
+		public string FirstLevelStartQuotationMark { get { return "“"; } }
+		public string FirstLevelEndQuotationMark { get { return "”"; } }
+		public string SecondLevelStartQuotationMark { get { return ""; } }
+		public string SecondLevelEndQuotationMark { get { return ""; } }
+		public string ThirdLevelStartQuotationMark { get { return ""; } }
+		public string ThirdLevelEndQuotationMark { get { return ""; } }
+		public bool FirstLevelQuotesAreUnique { get { return true; } }
+	}
+
+	internal class TwoLevelCurlyQuotesProject : IScrProjectSettings
+	{
+		public string FirstLevelStartQuotationMark { get { return "“"; } }
+		public string FirstLevelEndQuotationMark { get { return "”"; } }
+		public string SecondLevelStartQuotationMark { get { return "‘"; } }
+		public string SecondLevelEndQuotationMark { get { return "’"; } }
+		public string ThirdLevelStartQuotationMark { get { return ""; } }
+		public string ThirdLevelEndQuotationMark { get { return ""; } }
+		public bool FirstLevelQuotesAreUnique { get { return true; } }
 	}
 }


### PR DESCRIPTION
This only happens when the project does not have all quote levels filled in and the text contains some < and > symbols and the first-level quotes are not << and >>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/95)
<!-- Reviewable:end -->
