### PR TITLE
HT-240: Improved error reporting when manually setting P8 project location

### DIFF
--- a/DistFiles/localization/HearThis.es.tmx
+++ b/DistFiles/localization/HearThis.es.tmx
@@ -314,12 +314,21 @@
         <seg>Hubo un problema al acceder a los archivos de datos de Paratext.</seg>
       </tuv>
     </tu>
-    <tu tuid="ChooseProject.ErrorSettingParatextProjectsFolder">
+    <tu tuid="ChooseProject.ErrorSettingPTProjFolderExceptionDetailsLabel">
       <tuv xml:lang="en">
-        <seg>An error occurred trying to set Paratext projects location to:\n{0}Error message:\n{0}</seg>
+        <seg>Error message:</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Se produjo un error al intentar establecer la ubicación de los proyectos Paratext a:\n{0}Mensaje de error:\n{0}</seg>
+        <seg>Mensaje de error:</seg>
+      </tuv>
+    </tu>
+    <tu tuid="ChooseProject.ErrorSettingParatextProjectsFolder">
+      <tuv xml:lang="en">
+        <seg>An error occurred trying to set Paratext projects location to:
+{0}</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Se produjo un error al intentar establecer la carpeta de los proyectos Paratext en:\n{0}</seg>
       </tuv>
     </tu>
     <tu tuid="ChooseProject.FindParatextProjectsFolder">

--- a/DistFiles/localization/HearThis.es.tmx
+++ b/DistFiles/localization/HearThis.es.tmx
@@ -328,7 +328,8 @@
 {0}</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Se produjo un error al intentar establecer la carpeta de los proyectos Paratext en:\n{0}</seg>
+        <seg>Se produjo un error al intentar establecer la carpeta de los proyectos Paratext en:
+{0}</seg>
       </tuv>
     </tu>
     <tu tuid="ChooseProject.FindParatextProjectsFolder">

--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -120,7 +120,7 @@ namespace HearThis
 				{
 					try
 					{
-						ScrTextCollection.Initialize(Settings.Default.UserSpecifiedParatext8ProjectsDir);
+						ParatextData.Initialize(Settings.Default.UserSpecifiedParatext8ProjectsDir);
 					}
 					catch (Exception ex)
 					{

--- a/src/HearThis/UI/ChooseProject.cs
+++ b/src/HearThis/UI/ChooseProject.cs
@@ -288,19 +288,17 @@ namespace HearThis.UI
 							dlg.SelectedPath);
 						Analytics.Track("ErrorSettingParatextProjectsFolder",
 							new Dictionary<string, string> { {"Error", ex.ToString()} });
-						// While researching HT-240, I was able to get a null object reference on occasion. Hopefully
-						// with the call stack, the Paratext team should be able to fix it, but for any such
-						// problem inside ParatextData (maybe for all exception types other than ApplicationException),
-						// I think it makes sense to have this code to get the call stack.
-						if (ex is NullReferenceException)
-							ErrorReport.ReportNonFatalExceptionWithMessage(ex, msg);
-						else
+						// For any problem inside ParatextData (other than ApplicationException), we want a report with
+						// the call stack so we can follow up with the Paratext team if needed.
+						if (ex is ApplicationException)
 						{
 							msg += Environment.NewLine +
 								LocalizationManager.GetString("ChooseProject.ErrorSettingPTProjFolderExceptionDetailsLabel", "Error message:") +
 								Environment.NewLine + ex.Message;
 							MessageBox.Show(msg, ProductName, MessageBoxButtons.OK, MessageBoxIcon.Warning);
 						}
+						else
+							ErrorReport.ReportNonFatalExceptionWithMessage(ex, msg);
 						return;
 					}
 					Settings.Default.UserSpecifiedParatext8ProjectsDir = ScrTextCollection.SettingsDirectory;

--- a/src/HearThis/UI/ChooseProject.cs
+++ b/src/HearThis/UI/ChooseProject.cs
@@ -1,8 +1,8 @@
 // --------------------------------------------------------------------------------------------
 
-#region // Copyright (c) 2015, SIL International. All Rights Reserved.
-// <copyright from='2011' to='2015' company='SIL International'>
-//		Copyright (c) 2015, SIL International. All Rights Reserved.
+#region // Copyright (c) 2018, SIL International. All Rights Reserved.
+// <copyright from='2011' to='2018' company='SIL International'>
+//		Copyright (c) 2018, SIL International. All Rights Reserved.
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
 // </copyright>
@@ -196,7 +196,7 @@ namespace HearThis.UI
 
 		private void NotifyUserOfParatextProblem(string message, params string[] additionalInfo)
 		{
-			additionalInfo.Aggregate(message, (current, s) => current + ("\r\n" + s));
+			additionalInfo.Aggregate(message, (current, s) => current + Environment.NewLine + s);
 
 			var result = ErrorReport.NotifyUserOfProblem(new ShowAlwaysPolicy(),
 				LocalizationManager.GetString("Common.Quit", "Quit"), ErrorResult.Abort, message);
@@ -279,12 +279,12 @@ namespace HearThis.UI
 				{
 					try
 					{
-						ScrTextCollection.Initialize(dlg.SelectedPath);
+						ParatextData.Initialize(dlg.SelectedPath);
 					}
 					catch (Exception ex)
 					{
 						var msg = String.Format(LocalizationManager.GetString("ChooseProject.ErrorSettingParatextProjectsFolder",
-							"An error occurred trying to set Paratext projects location to:\r{0}"),
+							"An error occurred trying to set Paratext projects location to:\n{0}"),
 							dlg.SelectedPath);
 						Analytics.Track("ErrorSettingParatextProjectsFolder",
 							new Dictionary<string, string> { {"Error", ex.ToString()} });
@@ -296,9 +296,9 @@ namespace HearThis.UI
 							ErrorReport.ReportNonFatalExceptionWithMessage(ex, msg);
 						else
 						{
-							msg += "\r" +
+							msg += Environment.NewLine +
 								LocalizationManager.GetString("ChooseProject.ErrorSettingPTProjFolderExceptionDetailsLabel", "Error message:") +
-								"\r" + ex.Message;
+								Environment.NewLine + ex.Message;
 							MessageBox.Show(msg, ProductName, MessageBoxButtons.OK, MessageBoxIcon.Warning);
 						}
 						return;


### PR DESCRIPTION
In case where ParatextData.ScrTextCollection is unable to successfully set the folder the user provides as the location where it should find Paratext project data. This does not exactly fix the problem reported in this issue, but it should make it possible for the Paratext developers to see the call stack and thus rectify the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/100)
<!-- Reviewable:end -->
