### PR TITLE
UI Improvements to Export

### DIFF
--- a/DistFiles/localization/HearThis.es.tmx
+++ b/DistFiles/localization/HearThis.es.tmx
@@ -612,10 +612,10 @@
     </tu>
     <tu tuid="MainWindow.SaveAutomatically">
       <tuv xml:lang="en">
-        <seg>HearThis automatically saves your work, while you use it. This button is just here to tell you that :-)  To create sound files for playing your recordings, click the Publish button.</seg>
+        <seg>HearThis automatically saves your work, while you use it. This button is just here to tell you that. To create sound files for playing your recordings, on the More menu, click Export Sound Files.</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>HearThis guarda automáticamente el trabajo, mientras que lo utilice. Este botón está aquí sólo para decirle :-) Para crear archivos de sonido para la reproducción de las grabaciones, haga clic en el botón Exportar.</seg>
+        <seg>HearThis guarda automáticamente el trabajo, mientras que lo utilice. Este botón está aquí sólo para decirle. Para crear archivos de sonido para la reproducción de las grabaciones, en el menú Más, haga clic en Exportar los archivos de sonido.</seg>
       </tuv>
     </tu>
     <tu tuid="MainWindow.WindowTitle">

--- a/src/HearThis/Publishing/PublishDialog.cs
+++ b/src/HearThis/Publishing/PublishDialog.cs
@@ -29,12 +29,13 @@ namespace HearThis.Publishing
 
 		private enum State
 		{
+			InitialDisplay,
 			Working,
 			Success,
 			Failure
 		}
 
-		private State _state;
+		private State _state = State.InitialDisplay;
 		private BackgroundWorker _worker;
 
 		private const char kAudioFormatRadioPrefix = '_';
@@ -80,7 +81,7 @@ namespace HearThis.Publishing
 			_rdoCurrentBook.Checked = _model.PublishOnlyCurrentBook;
 			_rdoCurrentBook.Text = string.Format(_rdoCurrentBook.Text, _model.PublishingInfoProvider.CurrentBookName);
 
-			_destinationLabel.Text = _model.PublishThisProjectPath;
+			UpdateDisplay();
 		}
 
 		protected bool ReallyDesignMode
@@ -100,15 +101,18 @@ namespace HearThis.Publishing
 
 		private void UpdateDisplay()
 		{
-			_destinationLabel.Text = _model.PublishThisProjectPath;
-
 			switch (_state)
 			{
+				case State.InitialDisplay:
+					_destinationLabel.Text = _model.PublishThisProjectPath;
+					Debug.Assert(_publishButton.Enabled, "Button state should already be correct. Display should never revert to this state.");
+					break;
 				case State.Working:
 					_publishButton.Enabled = false;
 					_changeDestinationLink.Enabled = false;
 					tableLayoutPanelAudioFormat.Controls.OfType<RadioButton>().ForEach(b => b.Enabled = false);
 					tableLayoutPanelVerseIndexFormat.Controls.OfType<RadioButton>().ForEach(b => b.Enabled = false);
+					_tableLayoutPanelBooksToPublish.Controls.OfType<RadioButton>().ForEach(b => b.Enabled = false);
 					break;
 				case State.Success:
 				case State.Failure:

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -274,7 +274,7 @@ namespace HearThis.UI
 		{
 			MessageBox.Show(
 				LocalizationManager.GetString("MainWindow.SaveAutomatically",
-					"HearThis automatically saves your work, while you use it. This button is just here to tell you that :-)  To create sound files for playing your recordings, click the Publish button."),
+					"HearThis automatically saves your work, while you use it. This button is just here to tell you that. To create sound files for playing your recordings, on the More menu, click Export Sound Files."),
 				LocalizationManager.GetString("Common.Save", "Save"));
 		}
 


### PR DESCRIPTION
HT-290: Keep Export button enabled when user changes destination folder.
HT-264, HT-215: Updated message that user sees when the Save button is clicked so that it accurately reflects current UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/111)
<!-- Reviewable:end -->
