### PR TITLE
HT-265: Fixed bug: File.Copy failed because it couldn't overwrite file when doing Android synch.

### DIFF
--- a/Copy Libaries.bat
+++ b/Copy Libaries.bat
@@ -25,6 +25,9 @@ copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Windows.Forms.pdb 
 copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Core.dll  lib\dotnet
 copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Core.pdb  lib\dotnet
 
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Core.Desktop.dll  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Core.Desktop.pdb  lib\dotnet
+
 copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Scripture.dll  lib\dotnet
 copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Scripture.pdb  lib\dotnet
 
@@ -36,6 +39,9 @@ copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\L10NSharp.pdb  lib\dot
 
 copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Media.dll  lib\dotnet
 copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Media.pdb  lib\dotnet
+
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.WritingSystems.dll  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.WritingSystems.pdb  lib\dotnet
 
 :end
 @pause

--- a/Copy Libaries.bat
+++ b/Copy Libaries.bat
@@ -1,26 +1,41 @@
-REM For this to work, you need palaso as a sibling of this project
+REM For this to work, you need libpalaso (or palaso) as a sibling of this project
 set palaso=libpalaso
 if NOT EXIST ..\%palaso% set palaso=palaso
 
-copy /Y ..\%palaso%\output\debug\SIL.Windows.Forms.DblBundle.dll  lib\dotnet
-copy /Y ..\%palaso%\output\debug\SIL.Windows.Forms.DblBundle.pdb  lib\dotnet
+@REM set palasoConfigToUseForHearThis=DebugStrongName
+if "%palasoConfigToUseForHearThis%"=="" (
+  if "%1"=="" (
+    set palasoConfigToUseForHearThis=debug
+  ) ELSE (
+    set palasoConfigToUseForHearThis=%1
+  )
+) 
 
-copy /Y ..\%palaso%\output\debug\SIL.Windows.Forms.dll  lib\dotnet
-copy /Y ..\%palaso%\output\debug\SIL.Windows.Forms.pdb  lib\dotnet
+if NOT EXIST ..\%palaso%\output\%palasoConfigToUseForHearThis%\*.dll (
+  @echo ..\%palaso%\output\%palasoConfigToUseForHearThis% is not a valid source of libpalaso DLLs
+  goto end
+)
 
-copy /Y ..\%palaso%\output\debug\SIL.Core.dll  lib\dotnet
-copy /Y ..\%palaso%\output\debug\SIL.Core.pdb  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Windows.Forms.DblBundle.dll  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Windows.Forms.DblBundle.pdb  lib\dotnet
 
-copy /Y ..\%palaso%\output\debug\SIL.Scripture.dll  lib\dotnet
-copy /Y ..\%palaso%\output\debug\SIL.Scripture.pdb  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Windows.Forms.dll  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Windows.Forms.pdb  lib\dotnet
 
-copy /Y ..\%palaso%\output\debug\SIL.DblBundle.dll  lib\dotnet
-copy /Y ..\%palaso%\output\debug\SIL.DblBundle.pdb  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Core.dll  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Core.pdb  lib\dotnet
 
-copy /Y ..\%palaso%\output\debug\L10NSharp.dll  lib\dotnet
-copy /Y ..\%palaso%\output\debug\L10NSharp.pdb  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Scripture.dll  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Scripture.pdb  lib\dotnet
 
-copy /Y ..\%palaso%\output\debug\SIL.Media.dll  lib\dotnet
-copy /Y ..\%palaso%\output\debug\SIL.Media.pdb  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.DblBundle.dll  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.DblBundle.pdb  lib\dotnet
 
-pause
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\L10NSharp.dll  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\L10NSharp.pdb  lib\dotnet
+
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Media.dll  lib\dotnet
+copy /Y ..\%palaso%\output\%palasoConfigToUseForHearThis%\SIL.Media.pdb  lib\dotnet
+
+:end
+@pause

--- a/src/HearThis/Communication/AndroidSynchronization.cs
+++ b/src/HearThis/Communication/AndroidSynchronization.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Windows.Forms;
 using HearThis.Script;
 using HearThis.UI;
+using SIL.IO;
 
 namespace HearThis.Communication
 {
@@ -57,7 +58,7 @@ namespace HearThis.Communication
 					merger.Merge(dlg.ProgressBox);
 					//Update info.txt on Android
 					var infoFilePath = project.GetProjectRecordingStatusInfoFilePath();
-					File.WriteAllText(infoFilePath, project.GetProjectRecordingStatusInfoFileContent());
+					RobustFile.WriteAllText(infoFilePath, project.GetProjectRecordingStatusInfoFileContent());
 					var theirInfoTxtPath = project.Name + "/" + Project.InfoTxtFileName;
 					theirLink.PutFile(theirInfoTxtPath, File.ReadAllBytes(infoFilePath));
 					theirLink.SendNotification("syncCompleted");

--- a/src/HearThis/Communication/WindowsLink.cs
+++ b/src/HearThis/Communication/WindowsLink.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Text;
+using SIL.IO;
 
 namespace HearThis.Communication
 {
@@ -13,7 +12,7 @@ namespace HearThis.Communication
 	/// </summary>
 	class WindowsLink : IAndroidLink
 	{
-		private string _rootFolderPath;
+		private readonly string _rootFolderPath;
 		public WindowsLink(string rootFolderPath)
 		{
 			_rootFolderPath = rootFolderPath;
@@ -27,27 +26,27 @@ namespace HearThis.Communication
 		public bool GetFile(string sourceInRootFolder, string destPath)
 		{
 			var source = Path.Combine(_rootFolderPath, sourceInRootFolder);
-			if (!File.Exists(source))
+			if (!RobustFile.Exists(source))
 				return false;
-			File.Copy(source, destPath);
+			RobustFile.Copy(source, destPath, true);
 			return true;
 		}
 
 		public bool TryGetData(string androidPath, out byte[] data)
 		{
 			var path = Path.Combine(_rootFolderPath, androidPath);
-			if (!File.Exists(path))
+			if (!RobustFile.Exists(path))
 			{
 				data = new byte[0];
 				return false;
 			}
-			data = File.ReadAllBytes(path);
+			data = RobustFile.ReadAllBytes(path);
 			return true;
 		}
 
 		public bool PutFile(string androidPath, byte[] data)
 		{
-			File.WriteAllBytes(Path.Combine(_rootFolderPath, androidPath), data);
+			RobustFile.WriteAllBytes(Path.Combine(_rootFolderPath, androidPath), data);
 			return true;
 		}
 
@@ -64,7 +63,7 @@ namespace HearThis.Communication
 				sb.Append(";");
 				sb.Append(
 					new FileInfo(file).LastWriteTimeUtc.ToString(
-						new DateTimeFormatInfo() {FullDateTimePattern = "yyyy-MM-dd HH:mm:ss"}));
+						new DateTimeFormatInfo {FullDateTimePattern = "yyyy-MM-dd HH:mm:ss"}));
 				sb.Append(";f\n");
 			}
 			foreach (var dir in Directory.EnumerateDirectories(path))
@@ -73,7 +72,7 @@ namespace HearThis.Communication
 				sb.Append(";");
 				sb.Append(
 					new DirectoryInfo(dir).LastWriteTimeUtc.ToString(
-						new DateTimeFormatInfo() { FullDateTimePattern = "yyyy-MM-dd HH:mm:ss" }));
+						new DateTimeFormatInfo { FullDateTimePattern = "yyyy-MM-dd HH:mm:ss" }));
 				sb.Append(";d\n");
 			}
 			list = sb.ToString();
@@ -82,8 +81,8 @@ namespace HearThis.Communication
 
 		public void DeleteFile(string androidPath)
 		{
-			if (File.Exists(androidPath))
-				File.Delete(androidPath);
+			if (RobustFile.Exists(androidPath))
+				RobustFile.Delete(androidPath);
 		}
 	}
 }

--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -12,7 +12,6 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Windows.Forms;
 using DesktopAnalytics;
 using HearThis.Properties;
@@ -56,7 +55,7 @@ namespace HearThis
 				if (DialogResult.Yes ==
 					MessageBox.Show(confirmationString, kProduct, MessageBoxButtons.YesNo, MessageBoxIcon.Warning))
 				{
-					File.Delete(userConfigSettingsPath);
+					RobustFile.Delete(userConfigSettingsPath);
 				}
 			}
 
@@ -74,7 +73,7 @@ namespace HearThis
 
 			if (args.Length == 1 && args[0].Trim() == "-afterInstall")
 			{
-				using (var dlg = new SIL.Windows.Forms.ReleaseNotes.ShowReleaseNotesDialog(Resources.HearThis,  FileLocator.GetFileDistributedWithApplication( "releaseNotes.md")))
+				using (var dlg = new SIL.Windows.Forms.ReleaseNotes.ShowReleaseNotesDialog(Resources.HearThis,  FileLocationUtilities.GetFileDistributedWithApplication( "releaseNotes.md")))
 				{
 					dlg.ShowDialog();
 				}
@@ -189,10 +188,10 @@ namespace HearThis
 			{
 				return ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal).FilePath;
 			}
-			catch (System.Configuration.ConfigurationErrorsException e)
+			catch (ConfigurationErrorsException e)
 			{
 				_pendingExceptionsToReportToAnalytics.Add(e);
-				File.Delete(e.Filename);
+				RobustFile.Delete(e.Filename);
 				return e.Filename;
 			}
 		}
@@ -201,7 +200,7 @@ namespace HearThis
 
 		private static void SetupLocalization()
 		{
-			var installedStringFileFolder = FileLocator.GetDirectoryDistributedWithApplication("localization");
+			var installedStringFileFolder = FileLocationUtilities.GetDirectoryDistributedWithApplication("localization");
 			var targetTmxFilePath = Path.Combine(kCompany, kProduct);
 			string desiredUiLangId = Settings.Default.UserInterfaceLanguage;
 			LocalizationManager = LocalizationManager.Create(desiredUiLangId, "HearThis", Application.ProductName, Application.ProductVersion,

--- a/src/HearThis/Publishing/AudiBibleEncoder.cs
+++ b/src/HearThis/Publishing/AudiBibleEncoder.cs
@@ -20,7 +20,7 @@ namespace HearThis.Publishing
 		{
 			progress.WriteMessage(LocalizationManager.GetString("AudiBibleEncoder.Progress", "   Converting to AudiBible format", "Appears in progress indicator"));
 			string args = string.Format("-c 1 {0} -r 22500 \"{1}.wav\"", sourcePath, destPathWithoutExtension);
-			string exePath = FileLocator.GetFileDistributedWithApplication("sox", "sox.exe");
+			string exePath = FileLocationUtilities.GetFileDistributedWithApplication("sox", "sox.exe");
 			progress.WriteVerbose(exePath + " " + args);
 			var result = CommandLineRunner.Run(exePath, args, "", 60 * 10, progress);
 			if (result.StandardError.Contains("FAIL"))

--- a/src/HearThis/Publishing/BunchOfFilesPublishingMethod.cs
+++ b/src/HearThis/Publishing/BunchOfFilesPublishingMethod.cs
@@ -8,6 +8,7 @@
 #endregion
 // --------------------------------------------------------------------------------------------
 using System.IO;
+using SIL.IO;
 
 namespace HearThis.Publishing
 {
@@ -26,7 +27,7 @@ namespace HearThis.Publishing
 
 			string searchPattern = string.Format(kFilenameFormat, GetBookIndex(bookName), "*", bookName, "*");
 			foreach (var file in Directory.GetFiles(rootFolderPath, searchPattern))
-				File.Delete(file);
+				RobustFile.Delete(file);
 		}
 
 		public override string GetFilePathWithoutExtension(string rootFolderPath, string bookName, int chapterNumber)

--- a/src/HearThis/Publishing/FlacEncoder.cs
+++ b/src/HearThis/Publishing/FlacEncoder.cs
@@ -20,7 +20,7 @@ namespace HearThis.Publishing
 			progress.WriteMessage(LocalizationManager.GetString("FlacEncoder.Progress","   Converting to flac", "Appears in progress indicator"));
 			//-f overwrite if already exists
 			string arguments = string.Format("\"{0}\" -f -o \"{1}.flac\"", sourcePath, destPathWithoutExtension);
-			ClipRepository.RunCommandLine(progress, FileLocator.GetFileDistributedWithApplication(false, "flac.exe"), arguments);
+			ClipRepository.RunCommandLine(progress, FileLocationUtilities.GetFileDistributedWithApplication(false, "flac.exe"), arguments);
 		}
 
 		public string FormatName

--- a/src/HearThis/Publishing/LameEncoder.cs
+++ b/src/HearThis/Publishing/LameEncoder.cs
@@ -27,7 +27,7 @@ namespace HearThis.Publishing
 		{
 			var destPath = destPathWithoutExtension + ".mp3";
 			if (File.Exists(destPath))
-				File.Delete(destPath);
+				RobustFile.Delete(destPath);
 
 			progress.WriteMessage(LocalizationManager.GetString("LameEncoder.Progress"," Converting to mp3", "Appears in progress indicator"));
 

--- a/src/HearThis/Publishing/OggEncoder.cs
+++ b/src/HearThis/Publishing/OggEncoder.cs
@@ -23,7 +23,7 @@ namespace HearThis.Publishing
 		{
 			progress.WriteMessage(LocalizationManager.GetString("OggEncoder.Progress", "   Converting to ogg format", "Appears in progress indicator"));
 			string args = string.Format("-c 1 {0} \"{1}.ogg\"", sourcePath, destPathWithoutExtension);
-			string exePath = FileLocator.GetFileDistributedWithApplication("sox","sox.exe");
+			string exePath = FileLocationUtilities.GetFileDistributedWithApplication("sox","sox.exe");
 			progress.WriteVerbose(exePath + " " + args);
 			var result =CommandLineRunner.Run(exePath, args, "", 60 * 10, progress);
 			if(result.StandardError.Contains("FAIL"))

--- a/src/HearThis/Publishing/PublishingMethodBase.cs
+++ b/src/HearThis/Publishing/PublishingMethodBase.cs
@@ -9,6 +9,7 @@
 // --------------------------------------------------------------------------------------------
 using System.IO;
 using HearThis.Script;
+using SIL.IO;
 using SIL.Progress;
 
 namespace HearThis.Publishing
@@ -81,7 +82,7 @@ namespace HearThis.Publishing
 				return;
 
 			foreach (var file in Directory.GetFiles(path))
-				File.Delete(file);
+				RobustFile.Delete(file);
 		}
 	}
 }

--- a/src/HearThis/Publishing/WavEncoder.cs
+++ b/src/HearThis/Publishing/WavEncoder.cs
@@ -22,7 +22,7 @@ namespace HearThis.Publishing
 		{
 			//todo: sox input.wav -b 16 -r 41k output.wav
 			string args = string.Format("{0} -b 16 -c 1 -r 44.1k \"{1}.wav\"", sourcePath, destPathWithoutExtension);
-			string exePath = FileLocator.GetFileDistributedWithApplication("sox","sox.exe");
+			string exePath = FileLocationUtilities.GetFileDistributedWithApplication("sox","sox.exe");
 			progress.WriteVerbose(exePath + " " + args);
 			CommandLineRunner.Run(exePath, args, "", 60 * 10, progress);
 		}

--- a/src/HearThis/Script/BibleStats.cs
+++ b/src/HearThis/Script/BibleStats.cs
@@ -201,7 +201,7 @@ namespace HearThis.Script
 			_chaptersPerBook = new List<int>(kCanonicalBookCount);
 			_versesPerChapterPerBook = new Dictionary<int, int[]>();
 			int index = 0;
-			foreach (string line in File.ReadAllLines(FileLocator.GetFileDistributedWithApplication("chapterCounts.txt")))
+			foreach (string line in File.ReadAllLines(FileLocationUtilities.GetFileDistributedWithApplication("chapterCounts.txt")))
 			{
 				var parts = line.Trim().Split(new[] {'\t'});
 				if (parts.Length > 3)

--- a/src/HearThis/Script/ChapterInfo.cs
+++ b/src/HearThis/Script/ChapterInfo.cs
@@ -98,9 +98,7 @@ namespace HearThis.Script
 						ScriptLine block = chapterInfo.Recordings[i];
 						if (block.Number <= prevLineNumber)
 						{
-							var backup = Path.ChangeExtension(filePath, "corrupt");
-							File.Delete(backup);
-							File.Move(filePath, Path.ChangeExtension(filePath, "corrupt"));
+							RobustFile.ReplaceByCopyDelete(filePath, Path.ChangeExtension(filePath, "corrupt"), null);
 							chapterInfo.Recordings.RemoveRange(i, countOfRecordings - i);
 							chapterInfo.Save(filePath);
 							break;
@@ -224,14 +222,14 @@ namespace HearThis.Script
 			{
 				byte[] buffer = new byte[Resources.think.Length];
 				Resources.think.Read(buffer, 0, buffer.Length);
-				File.WriteAllBytes(sound.Path, buffer);
+				RobustFile.WriteAllBytes(sound.Path, buffer);
 				for (int line = 0; line < GetScriptBlockCount(); line++)
 				{
 					var path = ClipRepository.GetPathToLineRecording(_projectName, _bookName, ChapterNumber1Based, line, _scriptProvider);
 
 					if (!File.Exists(path))
 					{
-						File.Copy(sound.Path, path, false);
+						RobustFile.Copy(sound.Path, path);
 						OnScriptBlockRecorded(_scriptProvider.GetBlock(_bookNumber, ChapterNumber1Based, line));
 					}
 				}

--- a/src/HearThis/Script/ChapterInfo.cs
+++ b/src/HearThis/Script/ChapterInfo.cs
@@ -98,7 +98,7 @@ namespace HearThis.Script
 						ScriptLine block = chapterInfo.Recordings[i];
 						if (block.Number <= prevLineNumber)
 						{
-							RobustFile.ReplaceByCopyDelete(filePath, Path.ChangeExtension(filePath, "corrupt"), null);
+							RobustFileAddOn.Move(filePath, Path.ChangeExtension(filePath, "corrupt"), true);
 							chapterInfo.Recordings.RemoveRange(i, countOfRecordings - i);
 							chapterInfo.Save(filePath);
 							break;

--- a/src/HearThis/UI/AudioButtonsControl.cs
+++ b/src/HearThis/UI/AudioButtonsControl.cs
@@ -282,7 +282,7 @@ namespace HearThis.UI
 				try
 				{
 					// Can't use move because it doesn't allow overwrite
-					RobustFile.ReplaceByCopyDelete(Path, _backupPath, null);
+					RobustFileAddOn.Move(Path, _backupPath, true);
 					Analytics.Track("Re-recorded a clip", ContextForAnalytics);
 				}
 				catch (IOException err)

--- a/src/HearThis/UI/AudioButtonsControl.cs
+++ b/src/HearThis/UI/AudioButtonsControl.cs
@@ -17,6 +17,7 @@ using System.Windows.Forms;
 using DesktopAnalytics;
 using HearThis.Properties;
 using L10NSharp;
+using SIL.IO;
 using SIL.Media;
 using SIL.Media.Naudio;
 using SIL.Reporting;
@@ -280,21 +281,21 @@ namespace HearThis.UI
 			{
 				try
 				{
-					File.Copy(Path, _backupPath, true);
-					File.Delete(Path);
-					DesktopAnalytics.Analytics.Track("Re-recorded a clip", ContextForAnalytics);
+					// Can't use move because it doesn't allow overwrite
+					RobustFile.ReplaceByCopyDelete(Path, _backupPath, null);
+					Analytics.Track("Re-recorded a clip", ContextForAnalytics);
 				}
-				catch (Exception err)
+				catch (IOException err)
 				{
-					ErrorReport.NotifyUserOfProblem(err,
-						"Sigh. The old copy of that file is locked up, so we can't record over it at the moment. Yes, this problem will need to be fixed.");
+					ErrorReport.NotifyUserOfProblem(err, LocalizationManager.GetString("AudioButtonsControl.ErrorMovingExistingRecording",
+						"The file with the existing recording can not be overwritten. We can't record over it at the moment. Please report this error. Restarting HearThis might solve this problem."));
 					return false;
 				}
 			}
 			else
 			{
-				File.Delete(_backupPath);
-				DesktopAnalytics.Analytics.Track("Recording clip", ContextForAnalytics);
+				RobustFile.Delete(_backupPath);
+				Analytics.Track("Recording clip", ContextForAnalytics);
 			}
 			_startRecording = DateTime.Now;
 			//_startDelayTimer.Enabled = true;
@@ -441,7 +442,7 @@ namespace HearThis.UI
 					  LocalizationManager.GetString("AudioButtonsControl.RecordingProblem", "That recording has a problem. It will now be removed, if possible."));
 				try
 				{
-					File.Delete(_path);
+					RobustFile.Delete(_path);
 				}
 				catch (Exception)
 				{
@@ -467,7 +468,7 @@ namespace HearThis.UI
 				{
 					try
 					{
-						File.Delete(_path);
+						RobustFile.Delete(_path);
 					}
 					catch (Exception err)
 					{

--- a/src/HearThis/UI/MergeProgressDialog.cs
+++ b/src/HearThis/UI/MergeProgressDialog.cs
@@ -1,11 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using SIL.Windows.Forms.Progress;
 

--- a/src/HearThis/UI/RecordInPartsDlg.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Windows.Forms;
 using HearThis.Properties;
 using HearThis.Publishing;
+using L10NSharp;
 using SIL.IO;
 using SIL.Media.Naudio;
 using SIL.Progress;
@@ -27,9 +28,9 @@ namespace HearThis.UI
 		{
 			// TempFile creates empty files, but we don't want them to exist until there is a real
 			// recording to play, because it undesirably enables the play buttons.
-			File.Delete(_tempFile1.Path);
-			File.Delete(_tempFile2.Path);
-			File.Delete(_tempFileJoined.Path);
+			RobustFile.Delete(_tempFile1.Path);
+			RobustFile.Delete(_tempFile2.Path);
+			RobustFile.Delete(_tempFileJoined.Path);
 
 			InitializeComponent();
 			if (Settings.Default.RecordInPartsFormSettings == null)
@@ -310,17 +311,13 @@ namespace HearThis.UI
 				return;
 			try
 			{
-				File.Delete(destPath);
-				File.Copy(_tempFileJoined.Path, destPath);
+				RobustFile.Copy(_tempFileJoined.Path, destPath, true);
 			}
 			catch (Exception err)
 			{
-				// The corresponding problem in the AudioButtonsControl is not localizable, presumably because it was thought
-				// to unlikely to happen, so I haven't done it for this one either.
-				ErrorReport.NotifyUserOfProblem(err,
-					String.Format(
-						"Sigh. HearThis was unable to copy the combined recording to {0} where it belongs. Restarting HearThis might solve this problem.",
-						destPath));
+				ErrorReport.NotifyUserOfProblem(err, String.Format(LocalizationManager.GetString("RecordInParts.ErrorMovingExistingRecording",
+					"HearThis was unable to copy the combined recording to the correct destination:\r\n{0}\r\n" +
+					"Please report this error. Restarting HearThis might solve this problem."), destPath));
 			}
 		}
 

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -22,6 +22,7 @@ using HearThis.Publishing;
 using HearThis.Script;
 using L10NSharp;
 using SIL.Code;
+using SIL.IO;
 using SIL.Media.Naudio;
 using SIL.Windows.Forms.SettingProtection;
 using static System.String;
@@ -148,7 +149,7 @@ namespace HearThis.UI
 				{
 					try
 					{
-						File.Delete(skipPath);
+						RobustFile.Delete(skipPath);
 					}
 					catch (Exception e)
 					{

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -331,7 +331,7 @@ namespace HearThis.UI
 
 		private void OnAboutClick(object sender, EventArgs e)
 		{
-			using (var dlg = new SILAboutBox(FileLocator.GetFileDistributedWithApplication("aboutbox.htm")))
+			using (var dlg = new SILAboutBox(FileLocationUtilities.GetFileDistributedWithApplication("aboutbox.htm")))
 			{
 				dlg.CheckForUpdatesClicked += HandleAboutDialogCheckForUpdatesClick;
 				dlg.ReleaseNotesClicked += HandleAboutDialogReleaseNotesClicked;
@@ -341,7 +341,7 @@ namespace HearThis.UI
 
 		private void HandleAboutDialogReleaseNotesClicked(object sender, EventArgs e)
 		{
-			var path = FileLocator.GetFileDistributedWithApplication("ReleaseNotes.md");
+			var path = FileLocationUtilities.GetFileDistributedWithApplication("ReleaseNotes.md");
 			using (var dlg = new ShowReleaseNotesDialog(((Form)sender).Icon, path))
 				dlg.ShowDialog();
 		}
@@ -436,7 +436,7 @@ namespace HearThis.UI
 						}
 						else
 							Directory.CreateDirectory(hearThisProjectFolder);
-						File.Copy(name, projectFile);
+						RobustFile.Copy(name, projectFile);
 						name = projectFile;
 						bundle = new TextBundle<DblTextMetadata<DblMetadataLanguage>, DblMetadataLanguage>(name);
 					}

--- a/src/HearThis/UI/TextBundleScripture.cs
+++ b/src/HearThis/UI/TextBundleScripture.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Xml.XPath;
 using Paratext.Data;
 using SIL.DblBundle.Text;
+using SIL.IO;
 using SIL.Scripture;
 
 namespace HearThis.Script
@@ -33,9 +34,9 @@ namespace HearThis.Script
 			_bundle = bundle;
 
 			var stylesFile = Path.ChangeExtension(Path.GetTempFileName(), "sty");
-			File.WriteAllBytes(stylesFile, Properties.Resources.usfm);
+			RobustFile.WriteAllBytes(stylesFile, Properties.Resources.usfm);
 			_stylesheet = new ScrStylesheet(stylesFile);
-			File.Delete(stylesFile);
+			RobustFile.Delete(stylesFile);
 
 			// TODO: Update stylesheet from the info in the bundle.
 			//foreach (var s in _bundle.Stylesheet.Styles)
@@ -62,7 +63,7 @@ namespace HearThis.Script
 					var vrsFile = Path.ChangeExtension(Path.GetTempFileName(), "vrs");
 					_bundle.CopyVersificationFile(vrsFile);
 					_versification = SIL.Scripture.Versification.Table.Implementation.Load(vrsFile, "custom");
-					File.Delete(vrsFile);
+					RobustFile.Delete(vrsFile);
 				}
 				return _versification;
 			}

--- a/src/HearThis/Utils/Utils.cs
+++ b/src/HearThis/Utils/Utils.cs
@@ -8,6 +8,7 @@
 #endregion
 // --------------------------------------------------------------------------------------------
 using System.IO;
+using SIL.IO;
 
 namespace HearThis
 {
@@ -16,6 +17,19 @@ namespace HearThis
 		public static string CreateDirectory(params string[] pathparts)
 		{
 			return Directory.CreateDirectory(Path.Combine(pathparts)).FullName;
+		}
+	}
+
+	// ENHANCE: Modify the Move method in Libpalaso's RobustFile class to take this optional third parameter
+	// and then look at the myriad places where it's used that could be simplified by removing the code to
+	// check for and delete the destination file.
+	public static class RobustFileAddOn
+	{
+		public static void Move(string sourceFileName, string destFileName, bool overWrite = false)
+		{
+			if (RobustFile.Exists(destFileName))
+				RobustFile.Delete(destFileName);
+			RobustFile.Move(sourceFileName, destFileName);
 		}
 	}
 }


### PR DESCRIPTION
Duplicate bug reports: HT-292, HT-293
Also:
Replaced calls to File.Copy, File.Delete, File.Move, and File.Write... with corresponding RobustFile versions.
Replaced deprecated uses of FileLocator class.
Improved two error messages and made them localizable.
Other minor code cleanup.
Made CopyFiles batch file more flexible (now able to pull libpalaso DLLs from either debug or DebugStrongName)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/112)
<!-- Reviewable:end -->
