### PR TITLE
Fixed new Move method to actually take into consideration the overwrite parameter.

### DIFF
--- a/src/HearThis/Utils/Utils.cs
+++ b/src/HearThis/Utils/Utils.cs
@@ -27,7 +27,7 @@ namespace HearThis
 	{
 		public static void Move(string sourceFileName, string destFileName, bool overWrite = false)
 		{
-			if (RobustFile.Exists(destFileName))
+			if (overWrite && RobustFile.Exists(destFileName))
 				RobustFile.Delete(destFileName);
 			RobustFile.Move(sourceFileName, destFileName);
 		}


### PR DESCRIPTION
Since both existing callers pass true and I implemented it with the assumption that it was true, there's no functional problem in HearThis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/113)
<!-- Reviewable:end -->
