### PR TITLE
Fixed regression bug and performance problem in "Record in Parts" dialog

### DIFF
--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -40,6 +40,9 @@ the recorded files to that format, if necessary.
 
 # Release Notes
 
+## 3 July 2019
+- Critical performance improvement, especially affecting "Record in Parts" dialog box.
+
 ## 18 March 2019
 - Increased maximum clip recording time to 10 minutes.
 

--- a/src/HearThis/UI/AppPallette.cs
+++ b/src/HearThis/UI/AppPallette.cs
@@ -80,7 +80,7 @@ namespace HearThis.UI
 					{ColorSchemeElement.ScriptContextTextColor, CommonMuted },
 					{ColorSchemeElement.EmptyBoxColor, CommonMuted },
 					{ColorSchemeElement.HilightColor, NormalHighlight },
-					{ColorSchemeElement.SecondPartTextColor, NormalHighlight },
+					{ColorSchemeElement.SecondPartTextColor, HighContrastHighlight },
 					{ColorSchemeElement.SkippedLineColor, Color.FromArgb(166,132,0) }, //review
 					{ColorSchemeElement.Red, Color.FromArgb(215,2,0) },
 					{ColorSchemeElement.Blue, Color.FromArgb(00,8,118) },
@@ -99,7 +99,7 @@ namespace HearThis.UI
 					{ColorSchemeElement.ScriptContextTextColor, CommonMuted },
 					{ColorSchemeElement.EmptyBoxColor, CommonMuted },
 					{ColorSchemeElement.HilightColor, HighContrastHighlight },
-					{ColorSchemeElement.SecondPartTextColor, HighContrastHighlight},
+					{ColorSchemeElement.SecondPartTextColor, NormalHighlight},
 					{ColorSchemeElement.SkippedLineColor, HighContrastHighlight },  //review
 					{ColorSchemeElement.Red, Color.FromArgb(255,0,0) },
 					{ColorSchemeElement.Blue, Color.FromArgb(0,0,255) },

--- a/src/HearThis/UI/AudioButtonsControl.Designer.cs
+++ b/src/HearThis/UI/AudioButtonsControl.Designer.cs
@@ -33,7 +33,6 @@ namespace HearThis.UI
         private void InitializeComponent()
         {
 			this.components = new System.ComponentModel.Container();
-			this._startDelayTimer = new System.Windows.Forms.Timer(this.components);
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
 			this.l10NSharpExtender1 = new L10NSharp.UI.L10NSharpExtender(this.components);
 			this._nextButton = new HearThis.UI.ArrowButton();
@@ -41,11 +40,6 @@ namespace HearThis.UI
 			this._recordButton = new HearThis.UI.RecordButton();
 			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).BeginInit();
 			this.SuspendLayout();
-			// 
-			// _startDelayTimer
-			// 
-			this._startDelayTimer.Interval = 500;
-			this._startDelayTimer.Tick += new System.EventHandler(this.OnStartDelayTimerTick);
 			// 
 			// l10NSharpExtender1
 			// 
@@ -129,7 +123,6 @@ namespace HearThis.UI
 
         #endregion
 
-        private System.Windows.Forms.Timer _startDelayTimer;
         private System.Windows.Forms.ToolTip toolTip1;
         private RecordButton _recordButton;
         private PlayButton _playButton;

--- a/src/HearThis/UI/AudioButtonsControl.cs
+++ b/src/HearThis/UI/AudioButtonsControl.cs
@@ -275,7 +275,12 @@ namespace HearThis.UI
 			}
 
 			if (Recording)
+			{
+				Debug.WriteLine($"Recording is already true (Name = {Name})");
 				return false;
+			}
+			else
+				Debug.WriteLine($"Recording is false (Name = {Name})");
 
 			if (File.Exists(Path))
 			{
@@ -298,8 +303,7 @@ namespace HearThis.UI
 				Analytics.Track("Recording clip", ContextForAnalytics);
 			}
 			_startRecording = DateTime.Now;
-			//_startDelayTimer.Enabled = true;
-			//_startDelayTimer.Start();
+			Debug.WriteLine($"Calling _startRecordingTimer.Start() (Name = {Name})");
 			_startRecordingTimer.Start();
 			//_recordButton.ImagePressed = Resources.recordActive;
 			_recordButton.Waiting = true;
@@ -340,15 +344,14 @@ namespace HearThis.UI
 
 		void RaiseSoundFileCreated()
 		{
-			if (SoundFileCreated != null)
-				SoundFileCreated(this, new EventArgs());
+			SoundFileCreated?.Invoke(this, new EventArgs());
 		}
 
 		private void WarnPressTooShort()
 		{
 			MessageBox.Show(this, LocalizationManager.GetString("AudioButtonsControl.PleaseHold",
 				"Please hold the record button down until you have finished recording", "Appears when the button is pressed very briefly"),
-				 LocalizationManager.GetString("AudioButtonsControl.PressToRecord","Press to record", "Caption for PleaseHold message"));
+				 LocalizationManager.GetString("AudioButtonsControl.PressToRecord", "Press to record", "Caption for PleaseHold message"));
 			// If we had a prior recording, restore it...button press may have been a mistake.
 			if (File.Exists(_backupPath))
 			{
@@ -387,7 +390,7 @@ namespace HearThis.UI
 				return;
 			}
 			Invoke(new Action(delegate {
-				Debug.WriteLine("Start recording");
+				Debug.WriteLine($"Start recording (Name = {Name}; Path = {Path})");
 				Recorder.BeginRecording(Path);
 			   // _recordButton.ImagePressed = Resources.recordActive1;
 				_recordButton.Waiting = false;
@@ -400,15 +403,6 @@ namespace HearThis.UI
 			MessageBox.Show(this,
 				LocalizationManager.GetString("AudioButtonsControl.NoMic", "This computer appears to have no sound recording device available. You will need one to use this program."),
 				LocalizationManager.GetString("AudioButtonsControl.NoInput", "No input device"));
-		}
-
-		private void OnStartDelayTimerTick(object sender, EventArgs e)
-		{
-			_startRecordingTimer.Stop();
-			Debug.WriteLine("Start recording");
-			Recorder.BeginRecording(Path);
-
-			_recordButton.Waiting = false;
 		}
 
 		private void RecordAndPlayControl_Load(object sender, EventArgs e)
@@ -460,7 +454,7 @@ namespace HearThis.UI
 
 		void OnRecorder_Stopped(IAudioRecorder audioRecorder, ErrorEventArgs errorEventArgs)
 		{
-			Debug.WriteLine("_recorder_Stopped: requesting begin monitoring");
+			Debug.WriteLine($"_recorder_Stopped: requesting begin monitoring (Name = {Name})");
 
 			if (_recordButton.State == BtnState.Pushed)
 			{
@@ -541,8 +535,7 @@ namespace HearThis.UI
 
 		private void OnNextClick(object sender, EventArgs e)
 		{
-			if(NextClick !=null)
-				NextClick(sender, e);
+			NextClick?.Invoke(sender, e);
 		}
 	}
 

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -1080,6 +1080,7 @@ namespace HearThis.UI
 					_project.SelectedScriptBlock);
 				dlg.TextToRecord = scriptLine.Text;
 				dlg.RecordingDevice = _audioButtonsControl.RecordingDevice;
+				dlg.RecordingDeviceIndicator = recordingDeviceButton1;
 				dlg.ContextForAnalytics = _audioButtonsControl.ContextForAnalytics;
 				dlg.VernacularFont = new Font(scriptLine.FontName, scriptLine.FontSize * _scriptControl.ZoomFactor);
 				if (dlg.ShowDialog(this) == DialogResult.OK)
@@ -1088,6 +1089,7 @@ namespace HearThis.UI
 					OnSoundFileCreated(this, new EventArgs());
 				}
 			}
+			recordingDeviceButton1.Recorder = _audioButtonsControl.Recorder;
 		}
 
 		public void SetClauseSeparators(string clauseBreakCharacters)

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -351,6 +351,14 @@ namespace HearThis.UI
 			worker.RunWorkerAsync();
 		}
 
+		public bool MicCheckingEnabled
+		{
+			set
+			{
+				if (recordingDeviceButton1 != null)
+					recordingDeviceButton1.MicCheckingEnabled = value;
+			}
+		}
 		private BookButton SelectedBookButton => _bookFlow.Controls.OfType<BookButton>().SingleOrDefault(b => b.BookNumber == _project.SelectedBook.BookNumber);
 
 		private void HandleSelectedBookChanged(object sender, EventArgs e)

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -363,12 +363,14 @@ namespace HearThis.UI
 		{
 			base.OnActivated(e);
 			_recordingToolControl1.StartFilteringMessages();
+			_recordingToolControl1.MicCheckingEnabled = true;
 		}
 
 		protected override void OnDeactivate(EventArgs e)
 		{
 			base.OnDeactivate(e);
 			_recordingToolControl1.StopFilteringMessages();
+			_recordingToolControl1.MicCheckingEnabled = false;
 		}
 
 		private bool LoadProject(string name)


### PR DESCRIPTION
HT-334: Re-implemented contrasting colors for part 1 and part 2 highlights in "Record in Parts" dialog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/126)
<!-- Reviewable:end -->
