### PR TITLE
HT-338, HT-339: Prevent truncation of combined audio (part 2 omitted). Prevent crash for short recording.

### DIFF
--- a/DistFiles/localization/HearThis.es.tmx
+++ b/DistFiles/localization/HearThis.es.tmx
@@ -182,7 +182,7 @@
         <seg>Ha producido el siguiente error al preparar una sesión de audio para poder reproducir las grabaciones: \n{0}\nHearThis no funcionará correctamente sin altavoces.  Asegúrese de que los altavoces están activados y funcionando correctamente.\n¿Le gustaría que HearThis intentarlo de nuevo?</seg>
       </tuv>
     </tu>
-    <tu tuid="AudioButtonsControl.HoldButtonHint">
+    <tu tuid="AudioButtonsControl.PleaseHold">
       <note>Appears when the button is pressed very briefly</note>
       <tuv xml:lang="en">
         <seg>Hold down the record button (or the space bar) while talking, and only let it go when you're done.</seg>

--- a/DistFiles/localization/HearThis.es.tmx
+++ b/DistFiles/localization/HearThis.es.tmx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tmx version="1.4">
-  <header srclang="es" adminlang="en" creationtool="Palaso Localization Manager" creationtoolversion="3.0.43.0" segtype="block" datatype="unknown" o-tmf="PalasoTMXUtils">
+  <header srclang="es" adminlang="en" creationtool="Palaso Localization Manager" creationtoolversion="4.0.0.0" segtype="block" datatype="unknown" o-tmf="PalasoTMXUtils">
     <prop type="x-appversion">1.0.0.0</prop>
     <prop type="x-hardlinebreakreplacement">\n</prop>
   </header>
@@ -182,22 +182,13 @@
         <seg>Ha producido el siguiente error al preparar una sesión de audio para poder reproducir las grabaciones: \n{0}\nHearThis no funcionará correctamente sin altavoces.  Asegúrese de que los altavoces están activados y funcionando correctamente.\n¿Le gustaría que HearThis intentarlo de nuevo?</seg>
       </tuv>
     </tu>
-    <tu tuid="AudioButtonsControl.PleaseHold">
-      <note>Appears when the button is pressed very briefly</note>
+    <tu tuid="AudioButtonsControl.MaximumRecordingLength">
+      <note>Param 0: "HearThis" (product name); Param 1: maximum number of minutes</note>
       <tuv xml:lang="en">
-        <seg>Hold down the record button (or the space bar) while talking, and only let it go when you're done.</seg>
+        <seg>{0} currently limits recorded clips to {1} minutes. If you need to record longer clips, please contact support.</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Mantenga pulsado el botón de grabación (o la barra espaciadora) mientras habla, y sólo suelte el botón cuando haya terminado.</seg>
-      </tuv>
-    </tu>
-    <tu tuid="AudioButtonsControl.NextButton">
-      <note>Localize the tooltip, not the button name</note>
-      <tuv xml:lang="en">
-        <seg>_nextButton</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>_nextButton</seg>
+        <seg>{0} actualmente limita los clips grabados a {1} minutos. Si necesita grabar clips más largos, comuníquese con el soporte.</seg>
       </tuv>
     </tu>
     <tu tuid="AudioButtonsControl.NextButton_ToolTip_">
@@ -230,15 +221,6 @@
         <seg>Exportar de archivos de sonido</seg>
       </tuv>
     </tu>
-    <tu tuid="AudioButtonsControl.PlayButton">
-      <note>Localize the tooltip, not the button name</note>
-      <tuv xml:lang="en">
-        <seg>playButton1</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>playButton1</seg>
-      </tuv>
-    </tu>
     <tu tuid="AudioButtonsControl.PlayButton_ToolTip_">
       <note>Localize the tooltip, not the button name</note>
       <tuv xml:lang="en">
@@ -246,6 +228,15 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Reproducir el clip grabado para este bloque (tecla Tab)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="AudioButtonsControl.PleaseHold">
+      <note>Appears when the button is pressed very briefly</note>
+      <tuv xml:lang="en">
+        <seg>Hold down the record button (or the space bar) while talking, and only let it go when you're done.</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Mantenga pulsado el botón de grabación (o la barra espaciadora) mientras habla, y sólo suelte el botón cuando haya terminado.</seg>
       </tuv>
     </tu>
     <tu tuid="AudioButtonsControl.PressToRecord">
@@ -280,6 +271,23 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Esa grabación tiene un problema. Ahora será eliminado, si es posible.</seg>
+      </tuv>
+    </tu>
+    <tu tuid="AudioButtonsControl.RecordingProblemRestoreFromBackup">
+      <tuv xml:lang="en">
+        <seg>A backup of the previous recording is available. Would you like to restore it?</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Una copia de seguridad de la grabación anterior está disponible. ¿Desea restaurarlo?</seg>
+      </tuv>
+    </tu>
+    <tu tuid="AudioButtonsControl.RecordingStoppedMsgCaption">
+      <note>Displayed as the MessageBox caption when a clip recording exceeds the maximum number of minutes allowed.</note>
+      <tuv xml:lang="en">
+        <seg>Recording Stopped</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Grabación detenida</seg>
       </tuv>
     </tu>
     <tu tuid="AudioButtonsControl.ShortRecordingProblem">
@@ -652,6 +660,14 @@
         <seg>Tipo</seg>
       </tuv>
     </tu>
+    <tu tuid="PublishDialog.AudioFormat">
+      <tuv xml:lang="en">
+        <seg>Audio Format</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Formato de audio</seg>
+      </tuv>
+    </tu>
     <tu tuid="PublishDialog.Close">
       <note>Cancel Button text changes to this after publishing.</note>
       <tuv xml:lang="en">
@@ -693,22 +709,6 @@
         <seg>Carpeta de FLAC</seg>
       </tuv>
     </tu>
-    <tu tuid="PublishDialog.AudioFormat">
-      <tuv xml:lang="en">
-        <seg>Audio Format</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Formato de audio</seg>
-      </tuv>
-    </tu>
-    <tu tuid="PublishDialog.VerseIndexFormat">
-      <tuv xml:lang="en">
-        <seg>Verse Index Format</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Formato de índices de versículo</seg>
-      </tuv>
-    </tu>
     <tu tuid="PublishDialog.Mp3">
       <tuv xml:lang="en">
         <seg>Folder of MP3's</seg>
@@ -748,6 +748,14 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Al crear la aplicación usando Scripture App Builder, asegúrese de que los caracteres al final de una frase especificada en la página: 'Características - Audio', sólo incluyen la puntuación que termina frases utilizadas en el proyecto.</seg>
+      </tuv>
+    </tu>
+    <tu tuid="PublishDialog.VerseIndexFormat">
+      <tuv xml:lang="en">
+        <seg>Verse Index Format</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Formato de índices de versículo</seg>
       </tuv>
     </tu>
     <tu tuid="PublishDialog.WindowTitle">

--- a/DistFiles/localization/HearThis.es.tmx
+++ b/DistFiles/localization/HearThis.es.tmx
@@ -183,6 +183,7 @@
       </tuv>
     </tu>
     <tu tuid="AudioButtonsControl.HoldButtonHint">
+      <note>Appears when the button is pressed very briefly</note>
       <tuv xml:lang="en">
         <seg>Hold down the record button (or the space bar) while talking, and only let it go when you're done.</seg>
       </tuv>
@@ -247,17 +248,8 @@
         <seg>Reproducir el clip grabado para este bloque (tecla Tab)</seg>
       </tuv>
     </tu>
-    <tu tuid="AudioButtonsControl.PleaseHold">
-      <note>Appears when the button is pressed very briefly</note>
-      <tuv xml:lang="en">
-        <seg>Please hold the record button down until you have finished recording</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Por favor, mantenga el botón de grabación hasta que haya terminado de grabar</seg>
-      </tuv>
-    </tu>
     <tu tuid="AudioButtonsControl.PressToRecord">
-      <note>Caption for PleaseHold message</note>
+      <note>Caption for HoldButtonHint message</note>
       <tuv xml:lang="en">
         <seg>Press to record</seg>
       </tuv>

--- a/DistFiles/localization/HearThis.fr.tmx
+++ b/DistFiles/localization/HearThis.fr.tmx
@@ -224,6 +224,7 @@
       </tuv>
     </tu>
     <tu tuid="AudioButtonsControl.HoldButtonHint">
+      <note>Appears when the button is pressed very briefly</note>
       <tuv xml:lang="en">
         <seg>Hold down the record button (or the space bar) while talking, and only let it go when you're done.</seg>
       </tuv>
@@ -265,17 +266,8 @@
         <seg>Lire le clip enregistré pour ce bloc (touche Tab)</seg>
       </tuv>
     </tu>
-    <tu tuid="AudioButtonsControl.PleaseHold">
-      <note>Appears when the button is pressed very briefly</note>
-      <tuv xml:lang="en">
-        <seg>Please hold the record button down until you have finished recording</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Veuillez maintenir le bouton d'enregistrement enfoncé jusqu'à ce que vous ayez terminé l'enregistrement.</seg>
-      </tuv>
-    </tu>
     <tu tuid="AudioButtonsControl.PressToRecord">
-      <note>Caption for PleaseHold message</note>
+      <note>Caption for HoldButtonHint message</note>
       <tuv xml:lang="en">
         <seg>Press to record</seg>
       </tuv>

--- a/DistFiles/localization/HearThis.fr.tmx
+++ b/DistFiles/localization/HearThis.fr.tmx
@@ -223,7 +223,7 @@
         <seg>L'erreur suivante s'est produite lors de la préparation d'une session audio pour pouvoir lire des enregistrements :\n\n{0}\n\nHearThis ne fonctionnera pas correctement sans haut-parleurs. Assurez-vous que vos haut-parleurs sont activés et fonctionnent correctement.\nVoulez-vous que HearThis réessaye ?</seg>
       </tuv>
     </tu>
-    <tu tuid="AudioButtonsControl.HoldButtonHint">
+    <tu tuid="AudioButtonsControl.PleaseHold">
       <note>Appears when the button is pressed very briefly</note>
       <tuv xml:lang="en">
         <seg>Hold down the record button (or the space bar) while talking, and only let it go when you're done.</seg>

--- a/src/HearThis/UI/AudioButtonsControl.cs
+++ b/src/HearThis/UI/AudioButtonsControl.cs
@@ -347,7 +347,7 @@ namespace HearThis.UI
 		private bool BackupExists => File.Exists(_backupPath);
 		private bool RecordingExists => File.Exists(Path);
 
-		private string RecordingTooShortMessage => LocalizationManager.GetString("AudioButtonsControl.HoldButtonHint",
+		private string RecordingTooShortMessage => LocalizationManager.GetString("AudioButtonsControl.PleaseHold",
 			"Hold down the record button (or the space bar) while talking, and only let it go when you're done.",
 			"Appears when the button is pressed very briefly");
 

--- a/src/HearThis/UI/AudioButtonsControl.cs
+++ b/src/HearThis/UI/AudioButtonsControl.cs
@@ -329,6 +329,7 @@ namespace HearThis.UI
 			try
 			{
 				Debug.WriteLine("Stop recording");
+				Recorder.Stopped += RaiseSoundFileCreated;
 				Recorder.Stop(); //.StopRecordingAndSaveAsWav();
 			}
 			catch (Exception)
@@ -339,12 +340,15 @@ namespace HearThis.UI
 				WarnPressTooShort();
 
 			UpdateDisplay();
-			RaiseSoundFileCreated();
 		}
 
-		void RaiseSoundFileCreated()
+		void RaiseSoundFileCreated(IAudioRecorder sender, ErrorEventArgs args)
 		{
-			SoundFileCreated?.Invoke(this, new EventArgs());
+			Recorder.Stopped -= RaiseSoundFileCreated;
+			if (args == null)
+				SoundFileCreated?.Invoke(this, new EventArgs());
+			else
+				Logger.WriteError(args.GetException());
 		}
 
 		private void WarnPressTooShort()

--- a/src/HearThis/UI/CustomButton.cs
+++ b/src/HearThis/UI/CustomButton.cs
@@ -28,6 +28,13 @@ namespace HearThis.UI
 			}
 		}
 
+		public void RecordingWasAborted()
+		{
+			State = BtnState.Normal;
+			Capture = false;
+			CapturingMouse = false;
+		}
+
 		protected override void Draw(Graphics g)
 		{
 			int dim = Math.Min(Width, Height) - 2;
@@ -175,7 +182,7 @@ namespace HearThis.UI
 
 	public class CustomButton : Control
 	{
-		private bool CapturingMouse;
+		protected bool CapturingMouse { get; set; }
 		private BtnState _state = BtnState.Normal;
 		protected Pen _highlightPen;
 		private bool _isDefault;

--- a/src/HearThis/UI/RecordInPartsDlg.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.cs
@@ -21,7 +21,6 @@ namespace HearThis.UI
 		private TempFile _tempFile1 = TempFile.WithExtension("wav");
 		TempFile _tempFile2 = TempFile.WithExtension("wav");
 		private TempFile _tempFileJoined = TempFile.WithExtension("wav");
-		Timer _waitToJoinTimer = new Timer();
 		private Color _scriptSecondHalfColor = AppPallette.SecondPartTextColor;
 		private AudioButtonsControl _audioButtonCurrent;
 		private RecordingDeviceIndicator _recordingDeviceIndicator;
@@ -45,27 +44,6 @@ namespace HearThis.UI
 			_audioButtonsBoth.Path = _tempFileJoined.Path;
 			_audioButtonsFirst.SoundFileCreated += AudioButtonsOnSoundFileCreated;
 			_audioButtonsSecond.SoundFileCreated += AudioButtonsOnSoundFileCreated;
-			_waitToJoinTimer.Interval = 200;
-			_waitToJoinTimer.Tick += (sender, args) =>
-			{
-				_waitToJoinTimer.Stop();
-				// It seems that logically it should be possible to put this code simply in AudioButtonsOnSoundFileCreated.
-				// However when I do so the merge consistently fails; it behaves as if there is nothing in
-				// the most recently created sound file.
-				// It seems that the recording code is raising the event just barely before the recording is actually
-				// available. A short delay is the only way I've found to make the join work.
-				// Unfortunately I have no way of knowing how long the delay needs to be in general.
-				// On my fast development computer, 80ms is enough and 60ms is not. Will need to test on some slower
-				// machines.
-				var inputFiles = new[] {_tempFile1.Path, _tempFile2.Path};
-				if (RecordingExists(_tempFile2.Path))
-				{
-					ClipRepository.MergeAudioFiles(inputFiles, _tempFileJoined.Path, new NullProgress());
-					// Don't advance current, default play is to play just this bit next.
-					//_audioButtonCurrent = _audioButtonsBoth;
-				}
-				UpdateDisplay();
-			};
 			UpdateDisplay();
 			_recordTextBox.ForeColor = AppPallette.ScriptFocusTextColor;
 			BackColor = AppPallette.Background;
@@ -245,7 +223,17 @@ namespace HearThis.UI
 
 		private void AudioButtonsOnSoundFileCreated(object sender, EventArgs eventArgs)
 		{
-			_waitToJoinTimer.Start();
+			var inputFiles = new[] { _tempFile1.Path, _tempFile2.Path };
+			if (RecordingExists(_tempFile2.Path))
+			{
+				ClipRepository.MergeAudioFiles(inputFiles, _tempFileJoined.Path, new NullProgress());
+				// Don't advance current, default play is to play just this bit next.
+				//_audioButtonCurrent = _audioButtonsBoth;
+			}
+			else if (_audioButtonCurrent == _audioButtonsSecond)
+				throw new ApplicationException("AudioButtonsOnSoundFileCreated after recording clip 2, but the recording does not exist or is of length 0!");
+
+			UpdateDisplay();
 		}
 
 		public Font VernacularFont

--- a/src/HearThis/UI/RecordInPartsDlg.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.cs
@@ -42,8 +42,8 @@ namespace HearThis.UI
 			_audioButtonsFirst.Path = _tempFile1.Path;
 			_audioButtonsSecond.Path = _tempFile2.Path;
 			_audioButtonsBoth.Path = _tempFileJoined.Path;
-			_audioButtonsFirst.SoundFileCreated += AudioButtonsOnSoundFileCreated;
-			_audioButtonsSecond.SoundFileCreated += AudioButtonsOnSoundFileCreated;
+			_audioButtonsFirst.SoundFileRecordingComplete += AudioButtonsOnSoundFileCreated;
+			_audioButtonsSecond.SoundFileRecordingComplete += AudioButtonsOnSoundFileCreated;
 			UpdateDisplay();
 			_recordTextBox.ForeColor = AppPallette.ScriptFocusTextColor;
 			BackColor = AppPallette.Background;
@@ -223,15 +223,18 @@ namespace HearThis.UI
 
 		private void AudioButtonsOnSoundFileCreated(object sender, EventArgs eventArgs)
 		{
-			var inputFiles = new[] { _tempFile1.Path, _tempFile2.Path };
-			if (RecordingExists(_tempFile2.Path))
+			if (((AudioButtonsControl)sender).WasLastRecordingSuccessful)
 			{
-				ClipRepository.MergeAudioFiles(inputFiles, _tempFileJoined.Path, new NullProgress());
-				// Don't advance current, default play is to play just this bit next.
-				//_audioButtonCurrent = _audioButtonsBoth;
+				if (RecordingExists(_tempFile2.Path))
+				{
+					var inputFiles = new[] {_tempFile1.Path, _tempFile2.Path};
+					ClipRepository.MergeAudioFiles(inputFiles, _tempFileJoined.Path, new NullProgress());
+					// Don't advance current, default play is to play just this bit next.
+					//_audioButtonCurrent = _audioButtonsBoth;
+				}
+				else if (_audioButtonCurrent == _audioButtonsSecond)
+					throw new ApplicationException("AudioButtonsOnSoundFileCreated after recording clip 2, but the recording does not exist or is of length 0!");
 			}
-			else if (_audioButtonCurrent == _audioButtonsSecond)
-				throw new ApplicationException("AudioButtonsOnSoundFileCreated after recording clip 2, but the recording does not exist or is of length 0!");
 
 			UpdateDisplay();
 		}

--- a/src/HearThis/UI/RecordInPartsDlg.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.cs
@@ -221,9 +221,9 @@ namespace HearThis.UI
 			return true;
 		}
 
-		private void AudioButtonsOnSoundFileCreated(object sender, EventArgs eventArgs)
+		private void AudioButtonsOnSoundFileCreated(object sender, ErrorEventArgs eventArgs)
 		{
-			if (((AudioButtonsControl)sender).WasLastRecordingSuccessful)
+			if (eventArgs?.GetException() == null)
 			{
 				if (RecordingExists(_tempFile2.Path))
 				{

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -99,7 +99,7 @@ namespace HearThis.UI
 			_nextChapterLink.DisabledLinkColor = AppPallette.NavigationTextColor;
 			_nextChapterLink.LinkColor = AppPallette.HilightColor;
 
-			_audioButtonsControl.SoundFileCreated += OnSoundFileCreated;
+			_audioButtonsControl.SoundFileRecordingComplete += OnSoundFileCreated;
 			_audioButtonsControl.RecordingStarting += OnAudioButtonsControlRecordingStarting;
 
 			_breakLinesAtCommasButton.Checked = Settings.Default.BreakLinesAtClauses;

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -140,7 +140,7 @@ namespace HearThis.UI
 				!SettingsProtectionSettings.Default.NormallyHidden;
 		}
 
-		private void OnSoundFileCreated(object sender, EventArgs eventArgs)
+		private void OnSoundFileCreated(object sender, ErrorEventArgs eventArgs)
 		{
 			if (CurrentScriptLine.Skipped)
 			{
@@ -1086,7 +1086,7 @@ namespace HearThis.UI
 				if (dlg.ShowDialog(this) == DialogResult.OK)
 				{
 					dlg.WriteCombinedAudio(_project.GetPathToRecordingForSelectedLine());
-					OnSoundFileCreated(this, new EventArgs());
+					OnSoundFileCreated(this, null);
 				}
 			}
 			recordingDeviceButton1.Recorder = _audioButtonsControl.Recorder;


### PR DESCRIPTION
Rather than raising the SoundFileCreated event immediately after telling the Recorder to Stop and then waiting 200 ms after that event to attempt to write the combined audio, wait to raise the event until after the recorder is actually back in the Monitoring state (after going through the RequestedStop state).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/131)
<!-- Reviewable:end -->
