### PR TITLE
During recording, the script "context" text is muted

### DIFF
--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -40,6 +40,9 @@ the recorded files to that format, if necessary.
 
 # Release Notes
 
+## 14 October 2019
+- When recording or moving the mouse over a record button, the context is muted to prevent accidental recording of the context instead of the intended block.
+
 ## 3 July 2019
 - Critical performance improvement, especially affecting "Record in Parts" dialog box.
 

--- a/src/HearThis/UI/AppPallette.cs
+++ b/src/HearThis/UI/AppPallette.cs
@@ -56,15 +56,15 @@ namespace HearThis.UI
 			Blue,
 			Recording,
 			Titles,
-			LineBreakCommaActiveIcon,
-			RecordInPartsIcon,
 			ActorCharacterIcon,
-			CharactersIcon
+			CharactersIcon,
+			ScriptContextTextColorDuringRecording,
 		}
 
 		// all toolbar button images need to be this color
 		public static Color CommonMuted = Color.FromArgb(192,192,192);
 
+		private static Color NormalBackground = Color.FromArgb(65, 65, 65);
 		private static Color NormalHighlight = Color.FromArgb(245,212,17);
 		private static Color HighContrastHighlight = Color.FromArgb(0,255,0);
 
@@ -73,7 +73,7 @@ namespace HearThis.UI
 			{
 				ColorScheme.Normal, new Dictionary<ColorSchemeElement, Color>
 				{
-					{ColorSchemeElement.Background , Color.FromArgb(65,65,65) },
+					{ColorSchemeElement.Background, NormalBackground },
 					{ColorSchemeElement.MouseOverButtonBackColor, Color.FromArgb(78,78,78) },
 					{ColorSchemeElement.NavigationTextColor, CommonMuted },
 					{ColorSchemeElement.ScriptFocusTextColor, NormalHighlight },
@@ -85,8 +85,8 @@ namespace HearThis.UI
 					{ColorSchemeElement.Red, Color.FromArgb(215,2,0) },
 					{ColorSchemeElement.Blue, Color.FromArgb(00,8,118) },
 					{ColorSchemeElement.Recording, Color.FromArgb(57,165,0) },
-					{ColorSchemeElement.Titles, CommonMuted}
-
+					{ColorSchemeElement.Titles, CommonMuted},
+					{ColorSchemeElement.ScriptContextTextColorDuringRecording, ControlPaint.Light(NormalBackground,(float) .15)},
 				}
 			},
 			{
@@ -104,10 +104,10 @@ namespace HearThis.UI
 					{ColorSchemeElement.Red, Color.FromArgb(255,0,0) },
 					{ColorSchemeElement.Blue, Color.FromArgb(0,0,255) },
 					{ColorSchemeElement.Recording, Color.FromArgb(0,255,0) },
-					{ColorSchemeElement.Titles, CommonMuted }
+					{ColorSchemeElement.Titles, CommonMuted },
+					{ColorSchemeElement.ScriptContextTextColorDuringRecording, Color.FromArgb(100,100,100)},
 				}
 			}
-
 		};
 
 		public static readonly Dictionary<ColorScheme, Dictionary<ColorSchemeElement, Image>> ColorSchemeIcons = new Dictionary<ColorScheme, Dictionary<ColorSchemeElement, Image>>
@@ -162,17 +162,7 @@ namespace HearThis.UI
 		{
 			get { return ColorSchemeIcons[CurrentColorScheme][ColorSchemeElement.ActorCharacterIcon]; }
 		}
-
-//		public static Image LineBreakCommaActiveImage
-//		{
-//			get { return ColorSchemeIcons[CurrentColorScheme][ColorSchemeElement.LineBreakCommaActiveIcon]; }
-//		}
-//
-//		public static Image RecordInPartsImage
-//		{
-//			get { return ColorSchemeIcons[CurrentColorScheme][ColorSchemeElement.RecordInPartsIcon]; }
-//		}
-//
+		
 		public static Color Background
 		{
 			get { return ColorSchemes[CurrentColorScheme][ColorSchemeElement.Background]; }
@@ -205,6 +195,11 @@ namespace HearThis.UI
 		public static Color ScriptContextTextColor
 		{
 			get { return ColorSchemes[CurrentColorScheme][ColorSchemeElement.ScriptContextTextColor]; }
+		}
+
+		public static Color ScriptContextTextColorDuringRecording
+		{
+			get { return ColorSchemes[CurrentColorScheme][ColorSchemeElement.ScriptContextTextColorDuringRecording]; }
 		}
 
 		public static Color EmptyBoxColor
@@ -255,9 +250,6 @@ namespace HearThis.UI
 		public static Pen ButtonSuggestedPen = new Pen(ScriptFocusTextColor, 2);
 		public static Brush ButtonRecordingBrush = new SolidBrush(Recording);
 		public static Brush ButtonWaitingBrush = new SolidBrush(Red);
-
-		public static Brush ObfuscatedTextContextBrush = new SolidBrush(ControlPaint.Light(Background,(float) .3));
-		public static Brush ScriptContextTextBrush = new SolidBrush(ScriptContextTextColor);
 
 		private static Brush _blueBrush;
 		public static Brush BlueBrush => _blueBrush ?? (_blueBrush = new SolidBrush(Blue));

--- a/src/HearThis/UI/AudioButtonsControl.Designer.cs
+++ b/src/HearThis/UI/AudioButtonsControl.Designer.cs
@@ -20,8 +20,10 @@ namespace HearThis.UI
 		        {
 			        components.Dispose();
 		        }
-	        }
-	        base.Dispose(disposing);
+				_startRecordingTimer.Elapsed -= OnStartRecordingTimer_Elapsed;
+				_recordButton.ButtonStateChanged -= OnRecordButtonStateChanged;
+			}
+			base.Dispose(disposing);
         }
 
         #region Component Designer generated code

--- a/src/HearThis/UI/AudioButtonsControl.cs
+++ b/src/HearThis/UI/AudioButtonsControl.cs
@@ -13,7 +13,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.Remoting.Messaging;
 using System.Windows.Forms;
 using DesktopAnalytics;
 using HearThis.Properties;
@@ -22,7 +21,6 @@ using SIL.IO;
 using SIL.Media;
 using SIL.Media.Naudio;
 using SIL.Reporting;
-using SIL.Windows.Forms.Extensions;
 using Timer = System.Timers.Timer;
 
 namespace HearThis.UI
@@ -62,8 +60,13 @@ namespace HearThis.UI
 			_startRecordingTimer.Elapsed += OnStartRecordingTimer_Elapsed;
 
 			_recordButton.CancellableMouseDownCall = TryStartRecord;
-			_recordButton.ButtonStateChanged += (sender, args) => { RecordButtonStateChanged?.Invoke(this, _recordButton.State); };
+			_recordButton.ButtonStateChanged += OnRecordButtonStateChanged;
 			_backupPath = System.IO.Path.GetTempFileName();
+		}
+
+		private void OnRecordButtonStateChanged(object sender, EventArgs args)
+		{
+			RecordButtonStateChanged?.Invoke(this, _recordButton.State);
 		}
 
 

--- a/src/HearThis/UI/AudioButtonsControl.cs
+++ b/src/HearThis/UI/AudioButtonsControl.cs
@@ -37,6 +37,8 @@ namespace HearThis.UI
 		public event EventHandler NextClick;
 		public event ErrorEventHandler SoundFileRecordingComplete;
 		public event CancelEventHandler RecordingStarting;
+		public delegate void ButtonStateChangedHandler(object sender, BtnState newState);
+		public event ButtonStateChangedHandler RecordButtonStateChanged;
 
 		private readonly string _backupPath;
 		private DateTime _startRecording;
@@ -60,6 +62,7 @@ namespace HearThis.UI
 			_startRecordingTimer.Elapsed += OnStartRecordingTimer_Elapsed;
 
 			_recordButton.CancellableMouseDownCall = TryStartRecord;
+			_recordButton.ButtonStateChanged += (sender, args) => { RecordButtonStateChanged?.Invoke(this, _recordButton.State); };
 			_backupPath = System.IO.Path.GetTempFileName();
 		}
 

--- a/src/HearThis/UI/CustomButton.cs
+++ b/src/HearThis/UI/CustomButton.cs
@@ -186,6 +186,7 @@ namespace HearThis.UI
 		private BtnState _state = BtnState.Normal;
 		protected Pen _highlightPen;
 		private bool _isDefault;
+		public event EventHandler ButtonStateChanged;
 
 		public CustomButton()
 		{
@@ -235,6 +236,7 @@ namespace HearThis.UI
 				else if (_state != BtnState.Inactive && !Enabled)
 					Enabled = true;
 				Invalidate();
+				ButtonStateChanged?.Invoke(this, new EventArgs());
 			}
 		}
 

--- a/src/HearThis/UI/RecordInPartsDlg.Designer.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.Designer.cs
@@ -26,8 +26,8 @@ namespace HearThis.UI
 			this._labelBothOne = new System.Windows.Forms.Label();
 			this._labelBothTwo = new System.Windows.Forms.Label();
 			this.l10NSharpExtender1 = new L10NSharp.UI.L10NSharpExtender(this.components);
-			this._tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
 			this._labelDividerLine = new System.Windows.Forms.Label();
+			this._tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
 			this._audioButtonsBoth = new HearThis.UI.AudioButtonsControl();
 			this._audioButtonsSecond = new HearThis.UI.AudioButtonsControl();
 			this._audioButtonsFirst = new HearThis.UI.AudioButtonsControl();
@@ -191,6 +191,20 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.LocalizationManagerId = "HearThis";
 			this.l10NSharpExtender1.PrefixForNewItems = "RecordingControl";
 			// 
+			// _labelDividerLine
+			// 
+			this._labelDividerLine.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+			this._labelDividerLine.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this._tableLayoutPanel.SetColumnSpan(this._labelDividerLine, 5);
+			this.l10NSharpExtender1.SetLocalizableToolTip(this._labelDividerLine, null);
+			this.l10NSharpExtender1.SetLocalizationComment(this._labelDividerLine, null);
+			this.l10NSharpExtender1.SetLocalizingId(this._labelDividerLine, "RecordingControl.label1");
+			this._labelDividerLine.Location = new System.Drawing.Point(3, 48);
+			this._labelDividerLine.Margin = new System.Windows.Forms.Padding(3, 0, 3, 10);
+			this._labelDividerLine.Name = "_labelDividerLine";
+			this._labelDividerLine.Size = new System.Drawing.Size(635, 2);
+			this._labelDividerLine.TabIndex = 33;
+			// 
 			// _tableLayoutPanel
 			// 
 			this._tableLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -225,20 +239,6 @@ namespace HearThis.UI
 			this._tableLayoutPanel.Size = new System.Drawing.Size(641, 273);
 			this._tableLayoutPanel.TabIndex = 33;
 			// 
-			// _labelDividerLine
-			// 
-			this._labelDividerLine.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-			this._labelDividerLine.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-			this._tableLayoutPanel.SetColumnSpan(this._labelDividerLine, 5);
-			this.l10NSharpExtender1.SetLocalizableToolTip(this._labelDividerLine, null);
-			this.l10NSharpExtender1.SetLocalizationComment(this._labelDividerLine, null);
-			this.l10NSharpExtender1.SetLocalizingId(this._labelDividerLine, "RecordingControl.label1");
-			this._labelDividerLine.Location = new System.Drawing.Point(3, 48);
-			this._labelDividerLine.Margin = new System.Windows.Forms.Padding(3, 0, 3, 10);
-			this._labelDividerLine.Name = "_labelDividerLine";
-			this._labelDividerLine.Size = new System.Drawing.Size(635, 2);
-			this._labelDividerLine.TabIndex = 33;
-			// 
 			// _audioButtonsBoth
 			// 
 			this._audioButtonsBoth.Anchor = System.Windows.Forms.AnchorStyles.Left;
@@ -270,6 +270,7 @@ namespace HearThis.UI
 			this._audioButtonsSecond.RecordingDevice = null;
 			this._audioButtonsSecond.Size = new System.Drawing.Size(77, 43);
 			this._audioButtonsSecond.TabIndex = 22;
+			this._audioButtonsSecond.RecordButtonStateChanged += new HearThis.UI.AudioButtonsControl.ButtonStateChangedHandler(this.OnRecordButtonStateChanged);
 			// 
 			// _audioButtonsFirst
 			// 
@@ -285,6 +286,7 @@ namespace HearThis.UI
 			this._audioButtonsFirst.RecordingDevice = null;
 			this._audioButtonsFirst.Size = new System.Drawing.Size(77, 43);
 			this._audioButtonsFirst.TabIndex = 21;
+			this._audioButtonsFirst.RecordButtonStateChanged += new HearThis.UI.AudioButtonsControl.ButtonStateChangedHandler(this.OnRecordButtonStateChanged);
 			// 
 			// RecordInPartsDlg
 			// 

--- a/src/HearThis/UI/RecordInPartsDlg.Designer.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.Designer.cs
@@ -27,10 +27,10 @@ namespace HearThis.UI
 			this._labelBothTwo = new System.Windows.Forms.Label();
 			this.l10NSharpExtender1 = new L10NSharp.UI.L10NSharpExtender(this.components);
 			this._labelDividerLine = new System.Windows.Forms.Label();
-			this._tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
 			this._audioButtonsBoth = new HearThis.UI.AudioButtonsControl();
 			this._audioButtonsSecond = new HearThis.UI.AudioButtonsControl();
 			this._audioButtonsFirst = new HearThis.UI.AudioButtonsControl();
+			this._tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
 			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).BeginInit();
 			this._tableLayoutPanel.SuspendLayout();
 			this.SuspendLayout();
@@ -198,46 +198,13 @@ namespace HearThis.UI
 			this._tableLayoutPanel.SetColumnSpan(this._labelDividerLine, 5);
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._labelDividerLine, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._labelDividerLine, null);
-			this.l10NSharpExtender1.SetLocalizingId(this._labelDividerLine, "RecordingControl.label1");
+			this.l10NSharpExtender1.SetLocalizationPriority(this._labelDividerLine, L10NSharp.LocalizationPriority.NotLocalizable);
+			this.l10NSharpExtender1.SetLocalizingId(this._labelDividerLine, "RecordingControl.RecordInPartsDlg._labelDividerLine");
 			this._labelDividerLine.Location = new System.Drawing.Point(3, 48);
 			this._labelDividerLine.Margin = new System.Windows.Forms.Padding(3, 0, 3, 10);
 			this._labelDividerLine.Name = "_labelDividerLine";
 			this._labelDividerLine.Size = new System.Drawing.Size(635, 2);
 			this._labelDividerLine.TabIndex = 33;
-			// 
-			// _tableLayoutPanel
-			// 
-			this._tableLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this._tableLayoutPanel.ColumnCount = 5;
-			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this._tableLayoutPanel.Controls.Add(this._recordTextBox, 0, 2);
-			this._tableLayoutPanel.Controls.Add(this._labelBothTwo, 3, 5);
-			this._tableLayoutPanel.Controls.Add(this._instructionsLabel, 0, 0);
-			this._tableLayoutPanel.Controls.Add(this._labelBothOne, 1, 5);
-			this._tableLayoutPanel.Controls.Add(this.labelPlus, 2, 5);
-			this._tableLayoutPanel.Controls.Add(this._audioButtonsBoth, 4, 5);
-			this._tableLayoutPanel.Controls.Add(this._audioButtonsSecond, 4, 4);
-			this._tableLayoutPanel.Controls.Add(this._audioButtonsFirst, 4, 3);
-			this._tableLayoutPanel.Controls.Add(this._labelTwo, 3, 4);
-			this._tableLayoutPanel.Controls.Add(this._labelOne, 3, 3);
-			this._tableLayoutPanel.Controls.Add(this._labelDividerLine, 0, 1);
-			this._tableLayoutPanel.Location = new System.Drawing.Point(25, 25);
-			this._tableLayoutPanel.Name = "_tableLayoutPanel";
-			this._tableLayoutPanel.RowCount = 6;
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this._tableLayoutPanel.Size = new System.Drawing.Size(641, 273);
-			this._tableLayoutPanel.TabIndex = 33;
 			// 
 			// _audioButtonsBoth
 			// 
@@ -287,6 +254,40 @@ namespace HearThis.UI
 			this._audioButtonsFirst.Size = new System.Drawing.Size(77, 43);
 			this._audioButtonsFirst.TabIndex = 21;
 			this._audioButtonsFirst.RecordButtonStateChanged += new HearThis.UI.AudioButtonsControl.ButtonStateChangedHandler(this.OnRecordButtonStateChanged);
+			// 
+			// _tableLayoutPanel
+			// 
+			this._tableLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this._tableLayoutPanel.ColumnCount = 5;
+			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this._tableLayoutPanel.Controls.Add(this._recordTextBox, 0, 2);
+			this._tableLayoutPanel.Controls.Add(this._labelBothTwo, 3, 5);
+			this._tableLayoutPanel.Controls.Add(this._instructionsLabel, 0, 0);
+			this._tableLayoutPanel.Controls.Add(this._labelBothOne, 1, 5);
+			this._tableLayoutPanel.Controls.Add(this.labelPlus, 2, 5);
+			this._tableLayoutPanel.Controls.Add(this._audioButtonsBoth, 4, 5);
+			this._tableLayoutPanel.Controls.Add(this._audioButtonsSecond, 4, 4);
+			this._tableLayoutPanel.Controls.Add(this._audioButtonsFirst, 4, 3);
+			this._tableLayoutPanel.Controls.Add(this._labelTwo, 3, 4);
+			this._tableLayoutPanel.Controls.Add(this._labelOne, 3, 3);
+			this._tableLayoutPanel.Controls.Add(this._labelDividerLine, 0, 1);
+			this._tableLayoutPanel.Location = new System.Drawing.Point(25, 25);
+			this._tableLayoutPanel.Name = "_tableLayoutPanel";
+			this._tableLayoutPanel.RowCount = 6;
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this._tableLayoutPanel.Size = new System.Drawing.Size(641, 273);
+			this._tableLayoutPanel.TabIndex = 33;
 			// 
 			// RecordInPartsDlg
 			// 

--- a/src/HearThis/UI/RecordInPartsDlg.Designer.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.Designer.cs
@@ -26,10 +26,11 @@ namespace HearThis.UI
 			this._labelBothOne = new System.Windows.Forms.Label();
 			this._labelBothTwo = new System.Windows.Forms.Label();
 			this.l10NSharpExtender1 = new L10NSharp.UI.L10NSharpExtender(this.components);
+			this._tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+			this._labelDividerLine = new System.Windows.Forms.Label();
 			this._audioButtonsBoth = new HearThis.UI.AudioButtonsControl();
 			this._audioButtonsSecond = new HearThis.UI.AudioButtonsControl();
 			this._audioButtonsFirst = new HearThis.UI.AudioButtonsControl();
-			this._tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
 			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).BeginInit();
 			this._tableLayoutPanel.SuspendLayout();
 			this.SuspendLayout();
@@ -43,7 +44,7 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._labelOne, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._labelOne, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._labelOne, "RecordingControl.RecordInPartsDlg._labelOne");
-			this._labelOne.Location = new System.Drawing.Point(513, 231);
+			this._labelOne.Location = new System.Drawing.Point(538, 151);
 			this._labelOne.Margin = new System.Windows.Forms.Padding(0);
 			this._labelOne.Name = "_labelOne";
 			this._labelOne.Size = new System.Drawing.Size(26, 29);
@@ -59,7 +60,7 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._labelTwo, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._labelTwo, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._labelTwo, "RecordingControl.RecordInPartsDlg._labelTwo");
-			this._labelTwo.Location = new System.Drawing.Point(513, 274);
+			this._labelTwo.Location = new System.Drawing.Point(538, 194);
 			this._labelTwo.Margin = new System.Windows.Forms.Padding(0);
 			this._labelTwo.Name = "_labelTwo";
 			this._labelTwo.Size = new System.Drawing.Size(26, 29);
@@ -74,7 +75,7 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.labelPlus, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.labelPlus, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.labelPlus, "RecordingControl.RecordInPartsDlg.labelPlus");
-			this.labelPlus.Location = new System.Drawing.Point(498, 310);
+			this.labelPlus.Location = new System.Drawing.Point(523, 230);
 			this.labelPlus.Margin = new System.Windows.Forms.Padding(0);
 			this.labelPlus.Name = "labelPlus";
 			this.labelPlus.Size = new System.Drawing.Size(15, 43);
@@ -91,7 +92,7 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._cancelButton, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._cancelButton, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._cancelButton, "Common.Cancel");
-			this._cancelButton.Location = new System.Drawing.Point(384, 396);
+			this._cancelButton.Location = new System.Drawing.Point(409, 316);
 			this._cancelButton.Name = "_cancelButton";
 			this._cancelButton.Size = new System.Drawing.Size(75, 23);
 			this._cancelButton.TabIndex = 27;
@@ -107,7 +108,7 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._useRecordingsButton, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._useRecordingsButton, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._useRecordingsButton, "RecordingControl.RecordInPartsDlg.UseRecordingsButton");
-			this._useRecordingsButton.Location = new System.Drawing.Point(490, 396);
+			this._useRecordingsButton.Location = new System.Drawing.Point(515, 316);
 			this._useRecordingsButton.Name = "_useRecordingsButton";
 			this._useRecordingsButton.Size = new System.Drawing.Size(151, 23);
 			this._useRecordingsButton.TabIndex = 28;
@@ -129,8 +130,8 @@ namespace HearThis.UI
 			this._instructionsLabel.Location = new System.Drawing.Point(0, 0);
 			this._instructionsLabel.Margin = new System.Windows.Forms.Padding(0);
 			this._instructionsLabel.Name = "_instructionsLabel";
-			this._instructionsLabel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 10);
-			this._instructionsLabel.Size = new System.Drawing.Size(616, 44);
+			this._instructionsLabel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 14);
+			this._instructionsLabel.Size = new System.Drawing.Size(641, 48);
 			this._instructionsLabel.TabIndex = 29;
 			this._instructionsLabel.Text = "You can divide the line wherever you want. Just record the first part, then the s" +
     "econd part. If you want to, you can click in the text to help remember where the" +
@@ -144,10 +145,10 @@ namespace HearThis.UI
 			this._recordTextBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(65)))), ((int)(((byte)(65)))));
 			this._recordTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
 			this._recordTextBox.ForeColor = System.Drawing.SystemColors.ControlLightLight;
-			this._recordTextBox.Location = new System.Drawing.Point(3, 47);
+			this._recordTextBox.Location = new System.Drawing.Point(3, 63);
 			this._recordTextBox.Name = "_recordTextBox";
 			this._tableLayoutPanel.SetRowSpan(this._recordTextBox, 4);
-			this._recordTextBox.Size = new System.Drawing.Size(466, 303);
+			this._recordTextBox.Size = new System.Drawing.Size(491, 207);
 			this._recordTextBox.TabIndex = 30;
 			this._recordTextBox.Text = "";
 			// 
@@ -160,7 +161,7 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._labelBothOne, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._labelBothOne, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._labelBothOne, "RecordingControl.RecordInPartsDlg._labelBothOne");
-			this._labelBothOne.Location = new System.Drawing.Point(472, 317);
+			this._labelBothOne.Location = new System.Drawing.Point(497, 237);
 			this._labelBothOne.Margin = new System.Windows.Forms.Padding(0);
 			this._labelBothOne.Name = "_labelBothOne";
 			this._labelBothOne.Size = new System.Drawing.Size(26, 29);
@@ -177,7 +178,7 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._labelBothTwo, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._labelBothTwo, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._labelBothTwo, "RecordingControl.RecordInPartsDlg._labelBothTwo");
-			this._labelBothTwo.Location = new System.Drawing.Point(513, 317);
+			this._labelBothTwo.Location = new System.Drawing.Point(538, 237);
 			this._labelBothTwo.Margin = new System.Windows.Forms.Padding(0);
 			this._labelBothTwo.Name = "_labelBothTwo";
 			this._labelBothTwo.Size = new System.Drawing.Size(26, 29);
@@ -190,6 +191,54 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.LocalizationManagerId = "HearThis";
 			this.l10NSharpExtender1.PrefixForNewItems = "RecordingControl";
 			// 
+			// _tableLayoutPanel
+			// 
+			this._tableLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this._tableLayoutPanel.ColumnCount = 5;
+			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this._tableLayoutPanel.Controls.Add(this._recordTextBox, 0, 2);
+			this._tableLayoutPanel.Controls.Add(this._labelBothTwo, 3, 5);
+			this._tableLayoutPanel.Controls.Add(this._instructionsLabel, 0, 0);
+			this._tableLayoutPanel.Controls.Add(this._labelBothOne, 1, 5);
+			this._tableLayoutPanel.Controls.Add(this.labelPlus, 2, 5);
+			this._tableLayoutPanel.Controls.Add(this._audioButtonsBoth, 4, 5);
+			this._tableLayoutPanel.Controls.Add(this._audioButtonsSecond, 4, 4);
+			this._tableLayoutPanel.Controls.Add(this._audioButtonsFirst, 4, 3);
+			this._tableLayoutPanel.Controls.Add(this._labelTwo, 3, 4);
+			this._tableLayoutPanel.Controls.Add(this._labelOne, 3, 3);
+			this._tableLayoutPanel.Controls.Add(this._labelDividerLine, 0, 1);
+			this._tableLayoutPanel.Location = new System.Drawing.Point(25, 25);
+			this._tableLayoutPanel.Name = "_tableLayoutPanel";
+			this._tableLayoutPanel.RowCount = 6;
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this._tableLayoutPanel.Size = new System.Drawing.Size(641, 273);
+			this._tableLayoutPanel.TabIndex = 33;
+			// 
+			// _labelDividerLine
+			// 
+			this._labelDividerLine.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+			this._labelDividerLine.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this._tableLayoutPanel.SetColumnSpan(this._labelDividerLine, 5);
+			this.l10NSharpExtender1.SetLocalizableToolTip(this._labelDividerLine, null);
+			this.l10NSharpExtender1.SetLocalizationComment(this._labelDividerLine, null);
+			this.l10NSharpExtender1.SetLocalizingId(this._labelDividerLine, "RecordingControl.label1");
+			this._labelDividerLine.Location = new System.Drawing.Point(3, 48);
+			this._labelDividerLine.Margin = new System.Windows.Forms.Padding(3, 0, 3, 10);
+			this._labelDividerLine.Name = "_labelDividerLine";
+			this._labelDividerLine.Size = new System.Drawing.Size(635, 2);
+			this._labelDividerLine.TabIndex = 33;
+			// 
 			// _audioButtonsBoth
 			// 
 			this._audioButtonsBoth.Anchor = System.Windows.Forms.AnchorStyles.Left;
@@ -198,7 +247,7 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._audioButtonsBoth, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._audioButtonsBoth, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._audioButtonsBoth, "RecordingControl.RecordInPartsDlg.AudioButtonsControl");
-			this._audioButtonsBoth.Location = new System.Drawing.Point(539, 310);
+			this._audioButtonsBoth.Location = new System.Drawing.Point(564, 230);
 			this._audioButtonsBoth.Margin = new System.Windows.Forms.Padding(0);
 			this._audioButtonsBoth.Name = "_audioButtonsBoth";
 			this._audioButtonsBoth.Padding = new System.Windows.Forms.Padding(0, 5, 0, 0);
@@ -214,7 +263,7 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._audioButtonsSecond, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._audioButtonsSecond, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._audioButtonsSecond, "RecordingControl.RecordInPartsDlg.AudioButtonsControl");
-			this._audioButtonsSecond.Location = new System.Drawing.Point(539, 267);
+			this._audioButtonsSecond.Location = new System.Drawing.Point(564, 187);
 			this._audioButtonsSecond.Margin = new System.Windows.Forms.Padding(0);
 			this._audioButtonsSecond.Name = "_audioButtonsSecond";
 			this._audioButtonsSecond.Padding = new System.Windows.Forms.Padding(0, 5, 0, 0);
@@ -230,41 +279,12 @@ namespace HearThis.UI
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._audioButtonsFirst, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._audioButtonsFirst, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._audioButtonsFirst, "RecordingControl.RecordInPartsDlg.AudioButtonsControl");
-			this._audioButtonsFirst.Location = new System.Drawing.Point(539, 224);
+			this._audioButtonsFirst.Location = new System.Drawing.Point(564, 144);
 			this._audioButtonsFirst.Margin = new System.Windows.Forms.Padding(0);
 			this._audioButtonsFirst.Name = "_audioButtonsFirst";
 			this._audioButtonsFirst.RecordingDevice = null;
 			this._audioButtonsFirst.Size = new System.Drawing.Size(77, 43);
 			this._audioButtonsFirst.TabIndex = 21;
-			// 
-			// _tableLayoutPanel
-			// 
-			this._tableLayoutPanel.ColumnCount = 5;
-			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this._tableLayoutPanel.Controls.Add(this._recordTextBox, 0, 1);
-			this._tableLayoutPanel.Controls.Add(this._labelBothTwo, 3, 4);
-			this._tableLayoutPanel.Controls.Add(this._instructionsLabel, 0, 0);
-			this._tableLayoutPanel.Controls.Add(this._labelBothOne, 1, 4);
-			this._tableLayoutPanel.Controls.Add(this.labelPlus, 2, 4);
-			this._tableLayoutPanel.Controls.Add(this._audioButtonsBoth, 4, 4);
-			this._tableLayoutPanel.Controls.Add(this._audioButtonsSecond, 4, 3);
-			this._tableLayoutPanel.Controls.Add(this._audioButtonsFirst, 4, 2);
-			this._tableLayoutPanel.Controls.Add(this._labelTwo, 3, 3);
-			this._tableLayoutPanel.Controls.Add(this._labelOne, 3, 2);
-			this._tableLayoutPanel.Location = new System.Drawing.Point(25, 25);
-			this._tableLayoutPanel.Name = "_tableLayoutPanel";
-			this._tableLayoutPanel.RowCount = 5;
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this._tableLayoutPanel.Size = new System.Drawing.Size(616, 353);
-			this._tableLayoutPanel.TabIndex = 33;
 			// 
 			// RecordInPartsDlg
 			// 
@@ -272,15 +292,16 @@ namespace HearThis.UI
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(65)))), ((int)(((byte)(65)))));
 			this.CancelButton = this._cancelButton;
-			this.ClientSize = new System.Drawing.Size(659, 441);
+			this.ClientSize = new System.Drawing.Size(684, 361);
 			this.Controls.Add(this._tableLayoutPanel);
 			this.Controls.Add(this._useRecordingsButton);
 			this.Controls.Add(this._cancelButton);
 			this.l10NSharpExtender1.SetLocalizableToolTip(this, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this, null);
 			this.l10NSharpExtender1.SetLocalizingId(this, "RecordInPartsDlg.WindowTitle");
+			this.MaximumSize = new System.Drawing.Size(1100, 900);
 			this.MinimizeBox = false;
-			this.MinimumSize = new System.Drawing.Size(600, 350);
+			this.MinimumSize = new System.Drawing.Size(600, 330);
 			this.Name = "RecordInPartsDlg";
 			this.ShowIcon = false;
 			this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
@@ -308,5 +329,6 @@ namespace HearThis.UI
 		private System.Windows.Forms.Label _labelBothTwo;
 		private L10NSharp.UI.L10NSharpExtender l10NSharpExtender1;
 		private System.Windows.Forms.TableLayoutPanel _tableLayoutPanel;
+		private System.Windows.Forms.Label _labelDividerLine;
 	}
 }

--- a/src/HearThis/UI/RecordInPartsDlg.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.cs
@@ -24,6 +24,7 @@ namespace HearThis.UI
 		private Color _scriptSecondHalfColor = AppPallette.SecondPartTextColor;
 		private AudioButtonsControl _audioButtonCurrent;
 		private RecordingDeviceIndicator _recordingDeviceIndicator;
+		private Color _defaultForegroundColorForInstructions;
 
 		public RecordInPartsDlg()
 		{
@@ -34,6 +35,7 @@ namespace HearThis.UI
 			RobustFile.Delete(_tempFileJoined.Path);
 
 			InitializeComponent();
+			_defaultForegroundColorForInstructions = _instructionsLabel.ForeColor;
 			if (Settings.Default.RecordInPartsFormSettings == null)
 				Settings.Default.RecordInPartsFormSettings = FormSettings.Create(this);
 			_audioButtonCurrent = _audioButtonsFirst;
@@ -52,6 +54,15 @@ namespace HearThis.UI
 			_recordTextBox.ReadOnly = true;
 			Application.AddMessageFilter(this);
 			Closing += (sender, args) => Application.RemoveMessageFilter(this);
+			_audioButtonsFirst.RecordingStarting += RecordingStarting;
+			_audioButtonsSecond.RecordingStarting += RecordingStarting;
+		}
+
+		private void RecordingStarting(object sender, System.ComponentModel.CancelEventArgs e)
+		{
+			// Although the instructions are not actually script context, their proximity to the
+			// text to be recorded could be confusing, so we'll mute them during the recording.
+			_instructionsLabel.ForeColor = AppPallette.ScriptContextTextColorDuringRecording;
 		}
 
 		private static bool RecordingExists(string path)
@@ -105,7 +116,6 @@ namespace HearThis.UI
 			_useRecordingsButton.ForeColor = RecordingExists(_tempFile2.Path)
 				? SystemColors.ControlText
 				: SystemColors.ControlDark;
-			;
 		}
 
 		void AdvanceCurrent()
@@ -235,6 +245,9 @@ namespace HearThis.UI
 				else if (_audioButtonCurrent == _audioButtonsSecond)
 					throw new ApplicationException("AudioButtonsOnSoundFileCreated after recording clip 2, but the recording does not exist or is of length 0!");
 			}
+
+			if (!_audioButtonsFirst.Recording && !_audioButtonsSecond.Recording)
+				_instructionsLabel.ForeColor = _defaultForegroundColorForInstructions;
 
 			UpdateDisplay();
 		}

--- a/src/HearThis/UI/RecordInPartsDlg.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.cs
@@ -371,6 +371,15 @@ namespace HearThis.UI
 			_recordingDeviceIndicator.MicCheckingEnabled = false;
 		}
 
+		private void OnRecordButtonStateChanged(object sender, BtnState newState)
+		{
+			if (_audioButtonsFirst.Recording || _audioButtonsSecond.Recording)
+				return;
+			_instructionsLabel.ForeColor = (newState == BtnState.MouseOver) ?
+				AppPallette.ScriptContextTextColorDuringRecording :
+				_defaultForegroundColorForInstructions;
+		}
+
 		private void _useRecordingsButton_Click(object sender, EventArgs e)
 		{
 			// Can't use these recordings until we have both

--- a/src/HearThis/UI/RecordInPartsDlg.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.cs
@@ -264,12 +264,17 @@ namespace HearThis.UI
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				components.Dispose();
+				components?.Dispose();
 				_tempFile1.Dispose();
 				_tempFile2.Dispose();
 				_tempFileJoined.Dispose();
+				_audioButtonsFirst.SoundFileRecordingComplete -= AudioButtonsOnSoundFileCreated;
+				_audioButtonsSecond.SoundFileRecordingComplete -= AudioButtonsOnSoundFileCreated;
+				_recordTextBox.SelectionChanged -= RecordTextBoxOnSelectionChanged;
+				_audioButtonsFirst.RecordingStarting -= RecordingStarting;
+				_audioButtonsSecond.RecordingStarting -= RecordingStarting;
 			}
 			base.Dispose(disposing);
 		}

--- a/src/HearThis/UI/RecordInPartsDlg.resx
+++ b/src/HearThis/UI/RecordInPartsDlg.resx
@@ -120,7 +120,4 @@
   <metadata name="l10NSharpExtender1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="l10NSharpExtender1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/src/HearThis/UI/RecordInPartsDlg.resx
+++ b/src/HearThis/UI/RecordInPartsDlg.resx
@@ -120,4 +120,7 @@
   <metadata name="l10NSharpExtender1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="l10NSharpExtender1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/src/HearThis/UI/RecordingToolControl.Designer.cs
+++ b/src/HearThis/UI/RecordingToolControl.Designer.cs
@@ -281,6 +281,7 @@ namespace HearThis.UI
 			this._audioButtonsControl.Size = new System.Drawing.Size(123, 43);
 			this._audioButtonsControl.TabIndex = 20;
 			this._audioButtonsControl.NextClick += new System.EventHandler(this.OnNextButton);
+			this._audioButtonsControl.RecordButtonStateChanged += new HearThis.UI.AudioButtonsControl.ButtonStateChangedHandler(this.OnRecordButtonStateChanged);
 			// 
 			// toolTip1
 			// 

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -118,6 +118,8 @@ namespace HearThis.UI
 				MessageBox.Show(this, Format(fmt, GetUnfilteredScriptBlock(_project.SelectedScriptBlock).ParagraphStyle), Program.kProduct);
 				cancelEventArgs.Cancel = true;
 			}
+
+			_scriptControl.RecordingInProgress = true;
 		}
 
 		protected override void OnHandleCreated(EventArgs e)
@@ -142,6 +144,7 @@ namespace HearThis.UI
 
 		private void OnSoundFileCreated(object sender, ErrorEventArgs eventArgs)
 		{
+			_scriptControl.RecordingInProgress = false;
 			if (CurrentScriptLine.Skipped)
 			{
 				var skipPath = Path.ChangeExtension(_project.GetPathToRecordingForSelectedLine(), "skip");
@@ -422,6 +425,7 @@ namespace HearThis.UI
 
 		private void UpdateDisplay()
 		{
+			_scriptControl.RecordingInProgress = _audioButtonsControl.Recording;
 			_skipButton.Enabled = HaveScript;
 			// Technically in overview mode we have something to record but we're not allowed to record it.
 			// Pretending we don't have something produces the desired effect of disabling the Record button.

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -122,6 +122,12 @@ namespace HearThis.UI
 			_scriptControl.RecordingInProgress = true;
 		}
 
+		private void OnRecordButtonStateChanged(object sender, BtnState newState)
+		{
+			if (!_scriptControl.RecordingInProgress)
+				_scriptControl.UserPreparingToRecord = newState == BtnState.MouseOver;
+		}
+
 		protected override void OnHandleCreated(EventArgs e)
 		{
 			base.OnHandleCreated(e);

--- a/src/HearThis/UI/ScriptControl.cs
+++ b/src/HearThis/UI/ScriptControl.cs
@@ -176,9 +176,6 @@ namespace HearThis.UI
 							(control.BrightenContext ? ControlPaint.Light(AppPallette.ScriptContextTextColor, .9f) :
 								AppPallette.ScriptContextTextColor)) :
 						AppPallette.ScriptFocusTextColor;
-					// TEMP
-					if (_context && !control.RecordingInProgress && control.BrightenContext)
-						Debug.WriteLine(_paintColor.ToString());
 				}
 				_graphics = graphics;
 				BoundsF = boundsF;

--- a/src/HearThis/UI/ScriptControl.cs
+++ b/src/HearThis/UI/ScriptControl.cs
@@ -36,6 +36,7 @@ namespace HearThis.UI
 		private bool _lockContextBrightness;
 		private Rectangle _brightenContextMouseZone;
 		private bool _recordingInProgress;
+		private bool _userPreparingToRecord;
 		public bool ShowSkippedBlocks { get; set; }
 
 		public ScriptControl()
@@ -172,7 +173,7 @@ namespace HearThis.UI
 				}
 				else
 				{
-					_paintColor = _context ? (control.RecordingInProgress ? AppPallette.ScriptContextTextColorDuringRecording :
+					_paintColor = _context ? (control.RecordingInProgress || control.UserPreparingToRecord ? AppPallette.ScriptContextTextColorDuringRecording :
 							(control.BrightenContext ? ControlPaint.Light(AppPallette.ScriptContextTextColor, .9f) :
 								AppPallette.ScriptContextTextColor)) :
 						AppPallette.ScriptFocusTextColor;
@@ -434,6 +435,7 @@ namespace HearThis.UI
 
 		internal SentenceClauseSplitter ClauseSplitter { get; private set;  }
 
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		public bool RecordingInProgress
 		{
 			get => _recordingInProgress;
@@ -442,6 +444,21 @@ namespace HearThis.UI
 				if (_recordingInProgress != value)
 				{
 					_recordingInProgress = value;
+					Invalidate();
+				}
+			}
+		}
+
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public bool UserPreparingToRecord
+		{
+			get => _userPreparingToRecord;
+			set
+			{
+				Debug.Assert(!RecordingInProgress);
+				if (_userPreparingToRecord != value)
+				{
+					_userPreparingToRecord = value;
 					Invalidate();
 				}
 			}

--- a/src/HearThisTests/ScriptLinePainterTests.cs
+++ b/src/HearThisTests/ScriptLinePainterTests.cs
@@ -21,7 +21,7 @@ namespace HearThisTests
 			using (var testForm = new Form())
 			using (var gr = testForm.CreateGraphics())
 			{
-				var painter = new ScriptControl.ScriptBlockPainter(1.0f, null, Color.Black, gr, block, rect, 12, true);
+				var painter = new ScriptControl.ScriptBlockPainter(1.0f, Color.Black, gr, block, rect, 12, true);
 				// Given that all the text fits easily, DoMaxHeight should return whatever the paint function returns.
 				// The paint function should be passed all the text.
 				Assert.That(painter.DoMaxHeight(500, input =>
@@ -50,7 +50,7 @@ namespace HearThisTests
 			using (var testForm = new Form())
 			using (var gr = testForm.CreateGraphics())
 			{
-				var painter = new ScriptControl.ScriptBlockPainter(1.0f, null, Color.Black, gr, block, rect, 12, true);
+				var painter = new ScriptControl.ScriptBlockPainter(1.0f, Color.Black, gr, block, rect, 12, true);
 				// Below min height, paints nothing.
 				Assert.That(painter.DoMaxHeight(5, input =>
 				{
@@ -70,7 +70,7 @@ namespace HearThisTests
 			{
 				var size = gr.MeasureString("...with several words", font);
 				var rect = new RectangleF(0, 0, size.Width + 2, 500); // "...with several words" will just fit
-				var painter = new ScriptControl.ScriptBlockPainter(1.0f, null, Color.Black, gr, block, rect, 12, true);
+				var painter = new ScriptControl.ScriptBlockPainter(1.0f, Color.Black, gr, block, rect, 12, true);
 				// Paints the trailing words that fit.
 				Assert.That(painter.DoMaxHeight(size.Height + 2, input =>
 				{
@@ -90,7 +90,7 @@ namespace HearThisTests
 			{
 				var size = TextRenderer.MeasureText(gr, "words", font);
 				var rect = new RectangleF(0, 0, size.Width - 2, 500); //last word will not fit
-				var painter = new ScriptControl.ScriptBlockPainter(1.0f, null, Color.Black, gr, block, rect, 12, true);
+				var painter = new ScriptControl.ScriptBlockPainter(1.0f, Color.Black, gr, block, rect, 12, true);
 				// Does nothing.
 				Assert.That(painter.DoMaxHeight(size.Height + 2, input =>
 				{
@@ -110,7 +110,7 @@ namespace HearThisTests
 			{
 				var size = TextRenderer.MeasureText(gr, "Thisisatest", font);
 				var rect = new RectangleF(0, 0, size.Width - 2, 500); //nothing will fit
-				var painter = new ScriptControl.ScriptBlockPainter(1.0f, null, Color.Black, gr, block, rect, 12, true);
+				var painter = new ScriptControl.ScriptBlockPainter(1.0f, Color.Black, gr, block, rect, 12, true);
 				// Does nothing.
 				Assert.That(painter.DoMaxHeight(size.Height + 2, input =>
 				{
@@ -130,7 +130,7 @@ namespace HearThisTests
 			{
 				var size = TextRenderer.MeasureText(gr, "words", font);
 				var rect = new RectangleF(0, 0, size.Width +1, 500); //last word will fit, but not with the ...
-				var painter = new ScriptControl.ScriptBlockPainter(1.0f, null, Color.Black, gr, block, rect, 12, true);
+				var painter = new ScriptControl.ScriptBlockPainter(1.0f, Color.Black, gr, block, rect, 12, true);
 				// Does nothing
 				Assert.That(painter.DoMaxHeight(size.Height + 2, input =>
 				{
@@ -150,7 +150,7 @@ namespace HearThisTests
 			{
 				var size = gr.MeasureString("his is a test with several words", font);
 				var rect = new RectangleF(0, 0, size.Width + 1, 500); //all but one letter will fit
-				var painter = new ScriptControl.ScriptBlockPainter(1.0f, null, Color.Black, gr, block, rect, 12, true);
+				var painter = new ScriptControl.ScriptBlockPainter(1.0f, Color.Black, gr, block, rect, 12, true);
 				// Given that all the text fits easily, DoMaxHeight should return whatever the paint function returns.
 				// The paint function should be passed all the text.
 				Assert.That(painter.DoMaxHeight(size.Height + 2, input =>
@@ -171,7 +171,7 @@ namespace HearThisTests
 			{
 				var size = gr.MeasureString("his is a test with several words", font);
 				var rect = new RectangleF(0, 0, size.Width + 1, 500); //all but one letter will fit
-				var painter = new ScriptControl.ScriptBlockPainter(1.0f, null, Color.Black, gr, block, rect, 12, true);
+				var painter = new ScriptControl.ScriptBlockPainter(1.0f, Color.Black, gr, block, rect, 12, true);
 				Assert.That(painter.DoMaxHeight(size.Height * 2.5f, input =>
 				{
 					Assert.That(input, Is.EqualTo("This is a test with several words"));
@@ -195,7 +195,7 @@ namespace HearThisTests
 			{
 				var size = TextRenderer.MeasureText(gr, "several words", font);
 				var rect = new RectangleF(0, 0, size.Width + 1, 500);
-				var painter = new ScriptControl.ScriptBlockPainter(1.0f, null, Color.Black, gr, block, rect, 12, true);
+				var painter = new ScriptControl.ScriptBlockPainter(1.0f, Color.Black, gr, block, rect, 12, true);
 				Assert.That(painter.DoMaxHeight(size.Height * 2.5f, input =>
 				{
 					Assert.That(input, Is.EqualTo("... a test with several words"));


### PR DESCRIPTION
 This makes it nearly invisible so that the reader can't accidentally read the wrong thing.

Noticed that there was code to try to brighten the context when mouse goes over the script, so re-enabled that. However, the difference is very minimal and this may have been removed on purpose.

Also, did some cleanup to remove some unused code related to AppPalette and the ScriptControlPainter.

This change was motivated by:
https://community.scripture.software.sil.org/t/hearthis-to-sab-sound-file-misalignment/1171/7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/133)
<!-- Reviewable:end -->
