### PR TITLE
Installer improvments

### DIFF
--- a/DistFiles/localization/.guidsForInstaller.xml
+++ b/DistFiles/localization/.guidsForInstaller.xml
@@ -4,4 +4,6 @@
   <File Id="ProgramDir.localization.LocalizationsGoHere.txt" Guid="32b7a3f4-9a34-44b5-afa1-a6368511294b" />
   <File Id="ProgramDir.localization.HearThis.es.tmx" Guid="478d2dd3-5aea-4762-82f4-c7ad46a94b26" />
   <File Id="ProgramDir.localization.Palaso.es.tmx" Guid="8122b8bc-2760-4d58-b543-632215b97025" />
+  <File Id="ProgramDir.localization.Palaso.es.tmx" Guid="d729e4b6-43d1-4bf7-bde9-f96eec766181" />
+  <File Id="ProgramDir.localization.Palaso.fr.tmx" Guid="c0925df1-ffae-4e41-8f0e-03480111d327" />
 </InstallerMetadata>

--- a/DistFiles/localization/.guidsForInstaller.xml
+++ b/DistFiles/localization/.guidsForInstaller.xml
@@ -3,7 +3,7 @@
 <InstallerMetadata>
   <File Id="ProgramDir.localization.LocalizationsGoHere.txt" Guid="32b7a3f4-9a34-44b5-afa1-a6368511294b" />
   <File Id="ProgramDir.localization.HearThis.es.tmx" Guid="478d2dd3-5aea-4762-82f4-c7ad46a94b26" />
+  <File Id="ProgramDir.localization.HearThis.fr.tmx" Guid="55baedf6-a60c-4005-a391-4a57fb15fc9b" />
   <File Id="ProgramDir.localization.Palaso.es.tmx" Guid="8122b8bc-2760-4d58-b543-632215b97025" />
-  <File Id="ProgramDir.localization.Palaso.es.tmx" Guid="d729e4b6-43d1-4bf7-bde9-f96eec766181" />
   <File Id="ProgramDir.localization.Palaso.fr.tmx" Guid="c0925df1-ffae-4e41-8f0e-03480111d327" />
 </InstallerMetadata>

--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -36,16 +36,15 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
 	<WixVariable Id='WixUIDialogBmp' Value='installerBackground.jpg' />
 	<WixVariable Id="WixUILicenseRtf" Value="..\..\distfiles\License.rtf" />
 
-
 	<!--
 	"from the list: Don't use Advertise="yes" Advertised shortcuts are designed to allow
 users to install just the shortcut for your app, then demand-install the
 rest of the app the first time the icon is run.  If this is not behavior you
 are trying to support, you're better off using non-advertised shortcuts. "-->
 
-	<PropertyRef Id="NETFRAMEWORK40CLIENT" />
-	<Condition Message="Before HearThis can install on older computers, you need to install Microsoft's free .NET Framework 4.0 (at least the small 'client profile'.  A full discussion of HearThis's requirements can be found at http://HearThis.palaso.org/download ">
-	  Installed OR NETFRAMEWORK40CLIENT OR NETFRAMEWORK40FULL
+	<PropertyRef Id="WIX_IS_NETFRAMEWORK_461_OR_LATER_INSTALLED" />
+	<Condition Message="Before HearThis can install on older computers, you need to install Microsoft's free .NET Framework 4.6.1 or later (A full discussion of HearThis's requirements can be found at https://software.sil.org/hearthis/download/ ">
+	  Installed OR WIX_IS_NETFRAMEWORK_461_OR_LATER_INSTALLED
 	</Condition>
 
 	<!--because of bug, this needs to be 1 -->


### PR DESCRIPTION
Changed Installer to require .Net Framework 4.6.1
Also added installer GUIDs for Palaso localization files

WIP: Use redistributable C++ runtime instead of having the file checked into source and installed with HearThis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/137)
<!-- Reviewable:end -->
