### PR TITLE
HT-359: Paint custom heavy exclamation marks instead of drawing as strings

### DIFF
--- a/src/HearThis/UI/DiscontiguousProgressTrackBar.cs
+++ b/src/HearThis/UI/DiscontiguousProgressTrackBar.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Windows.Forms;
 using SIL.Code;
@@ -164,6 +165,8 @@ namespace HearThis.UI
 		{
 			int top = ThumbTop + ThumbHeightAboveBar;
 			int height = ThumbHeight / 5;
+
+			e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
 
 			//erase
 			e.Graphics.FillRectangle(AppPallette.BackgroundBrush, new Rectangle(0, 0, Width, Height));

--- a/src/HearThis/UI/DiscontiguousProgressTrackBar.cs
+++ b/src/HearThis/UI/DiscontiguousProgressTrackBar.cs
@@ -193,9 +193,9 @@ namespace HearThis.UI
 						}
 						if (i != Value)
 						{
-							if (_currentSegmentBrushes[i].Symbol != (char)0)
+							if (_currentSegmentBrushes[i].Symbol != null)
 							{
-								var text = _currentSegmentBrushes[i].Symbol.ToString();
+								var text = _currentSegmentBrushes[i].Symbol;
 								var size = e.Graphics.MeasureString(text, Font);
 								var leftString = segmentLeft + segmentWidth / 2 - size.Width / 2;
 								var topString = top + height / 2 - size.Height / 2;
@@ -211,23 +211,30 @@ namespace HearThis.UI
 					if (SegmentCount > Value)
 					{
 						var rect = ThumbRectangle;
-						var overlayText = (_currentSegmentBrushes[Value].Symbol != (char)0) ? _currentSegmentBrushes[Value].Symbol.ToString() : null;
+						var overlayText = _currentSegmentBrushes[Value].Symbol;
 						var fillBrush = _currentSegmentBrushes[Value].MainBrush;
 						if (fillBrush == Brushes.Transparent || overlayText != null)
 							fillBrush = AppPallette.DisabledBrush;
 
 						e.Graphics.FillRectangle(fillBrush, rect);
 
-						if (overlayText != null)
+						if (overlayText != null || _currentSegmentBrushes[Value].PaintIconDelegate != null)
 						{
-							e.Graphics.DrawRectangle(AppPallette.ProblemHighlightPen, new Rectangle(rect.Location, new Size(rect.Width, rect.Height - 1)));
-							var size = e.Graphics.MeasureString(overlayText, Font);
-							var leftString = rect.Left + rect.Width/2 - size.Width/2;
-							var topString = rect.Top + rect.Height/2 - size.Height/2;
-							e.Graphics.DrawString(overlayText, Font, _currentSegmentBrushes[Value].MainBrush, leftString, topString);
+							var boundingRect = new Rectangle(rect.Location, new Size(rect.Width, rect.Height - 1));
+							e.Graphics.DrawRectangle(AppPallette.ProblemHighlightPen, boundingRect);
+							if (overlayText != null)
+							{
+								var size = e.Graphics.MeasureString(overlayText, Font);
+								var leftString = rect.Left + rect.Width / 2 - size.Width / 2;
+								var topString = rect.Top + rect.Height / 2 - size.Height / 2;
+								e.Graphics.DrawString(overlayText, Font, _currentSegmentBrushes[Value].MainBrush, leftString, topString);
+							}
+
+							boundingRect.Y++;
+							boundingRect.Height--;
+							_currentSegmentBrushes[Value].PaintIconDelegate?.Invoke(
+								e.Graphics, boundingRect, true);
 						}
-						_currentSegmentBrushes[Value].PaintIconDelegate?.Invoke(
-							e.Graphics, new Rectangle(rect.Location, new Size(rect.Width, rect.Height - 1)), true);
 					}
 				}
 			}
@@ -359,7 +366,7 @@ namespace HearThis.UI
 	{
 		public Brush MainBrush;
 		public Brush UnderlineBrush;
-		public char Symbol;
+		public string Symbol;
 		public Action<Graphics, Rectangle, bool> PaintIconDelegate;
 	}
 }

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -448,7 +448,7 @@ namespace HearThis.UI
 					// NB: Skipped segments only get entries in the array of brushes if they are being shown(currently always, previously in "Admin" mode).
 					// If we are ever again hiding skipped segments, then we need to avoid putting these segments into the collection.
 					if (!HidingSkippedBlocks)
-						results[iBrush++] = new SegmentPaintInfo {MainBrush = mainBrush, Symbol = '/'};
+						results[iBrush++] = new SegmentPaintInfo {MainBrush = mainBrush, Symbol = "/"};
 				}
 				else
 				{
@@ -464,7 +464,7 @@ namespace HearThis.UI
 							if (DoesSegmentHaveProblems(i))
 							{
 								//seg.UnderlineBrush = AppPallette.ProblemBrush;
-								seg.PaintIconDelegate = (g, r, selected) => UnitNavigationButton.DrawIcon(g, r, Resources.exclamation_normal_highlight);
+								seg.PaintIconDelegate = (g, r, selected) => UnitNavigationButton.DrawExclamation(g, r, AppPallette.HighlightBrush);
 							}
 							else if (i == results.Length - 1 && _project.SelectedChapterInfo.HasRecordingInfoBeyondExtentOfCurrentScript)
 							{


### PR DESCRIPTION
This is a different approach to trying to get exclamation marks that are more visible. It definitely yields heavier, more noticeable exclamation marks, but depending on the size, the dithering isn't always optimal. Maybe I need to try drawing the entire top portion as a single polygon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/156)
<!-- Reviewable:end -->
