### PR TITLE
HT-370 (part 2): Make HearThis the active app when launched from bootstrapper

### DIFF
--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -66,6 +66,7 @@ namespace HearThis
 				}
 			}
 
+			bool launchedFromInstaller = (args.Any(a => a.Trim() == "-afterInstall"));
 			bool showReleaseNotes = false;
 
 			//bring in settings from any previous version
@@ -74,7 +75,13 @@ namespace HearThis
 				//see https://stackoverflow.com/questions/3498561/net-applicationsettingsbase-should-i-call-upgrade-every-time-i-load
 				Settings.Default.Upgrade();
 				Settings.Default.NeedUpgrade = false;
-				showReleaseNotes = true;
+				// If this is the first run of this version of HearThis and it was launched from
+				// the installer, we want to show the release notes.
+				// ENHANCE: Ideally, we probably only want to do this for major/minor version
+				// changes (or only if there's a new entry in Release notes since the last version).
+				// REVIEW: Do we want to display the release notes on first launch even if not
+				// from the installer?
+				showReleaseNotes = launchedFromInstaller;
 				Settings.Default.Save();
 			}
 			// As a safety measure, we always revert this advanced admin setting to false on restart.
@@ -83,14 +90,6 @@ namespace HearThis
 			SetUpErrorHandling();
 			SettingsProtectionSingleton.ProductSupportUrl = kSupportUrlSansHttps;
 			SetupLocalization();
-
-			if (showReleaseNotes)
-			{
-				using (var dlg = new SIL.Windows.Forms.ReleaseNotes.ShowReleaseNotesDialog(Resources.HearThis,  FileLocationUtilities.GetFileDistributedWithApplication( "releaseNotes.md")))
-				{
-					dlg.ShowDialog();
-				}
-			}
 
 			string userName = null;
 			string emailAddress = null;
@@ -185,7 +184,7 @@ namespace HearThis
 					Sldr.Initialize();
 				try
 				{
-					Application.Run(new Shell());
+					Application.Run(new Shell(launchedFromInstaller, showReleaseNotes));
 				}
 				finally
 				{

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -32,11 +32,12 @@ namespace HearThis.UI
 {
 	public partial class Shell : Form
 	{
+		private bool _showReleaseNotesOnActivated;
+		private bool _bringToFrontWhenShown;
 		private static Sparkle UpdateChecker;
 		public event EventHandler OnProjectChanged;
 		private string _projectNameToShow = string.Empty;
 		private bool _mouseInMultiVoicePanel;
-
 
 #if MULTIPLEMODES
 		private List<string> allowableModes;
@@ -45,8 +46,10 @@ namespace HearThis.UI
 #endif
 		private const string kNormalRecording = "NormalRecording";
 
-		public Shell()
+		public Shell(bool bringToFrontOnFirstActivation = false, bool showReleaseNotesOnStartup = false)
 		{
+			_bringToFrontWhenShown = bringToFrontOnFirstActivation;
+			_showReleaseNotesOnActivated = showReleaseNotesOnStartup;
 			InitializeComponent();
 			_toolStrip.BackColor = AppPallette.Background;
 			Text = Program.kProduct;
@@ -166,6 +169,22 @@ namespace HearThis.UI
 			// We don't want to do this until the main window is loaded because a) it's very easy for the user to overlook, and b)
 			// more importantly, when the toast notifier closes, it can sometimes clobber an error message being displayed for the user.
 			UpdateChecker.CheckOnFirstApplicationIdle();
+		}
+
+		protected override void OnVisibleChanged(EventArgs e)
+		{
+			base.OnVisibleChanged(e);
+			// This is a hack to get HearThis to become the active app when it is launched from the
+			// installer.
+			if (Visible && _bringToFrontWhenShown)
+			{
+				_bringToFrontWhenShown = false;
+				// No one could think this is "right" but it seems to be the only reliable way.
+				// See https://stackoverflow.com/questions/1463417/what-is-the-right-way-to-bring-a-windows-forms-application-to-the-foreground
+				WindowState = FormWindowState.Minimized;
+				Show();
+				WindowState = FormWindowState.Normal;
+			}
 		}
 
 		/// <summary>
@@ -365,6 +384,14 @@ namespace HearThis.UI
 		protected override void OnActivated(EventArgs e)
 		{
 			base.OnActivated(e);
+			if (_showReleaseNotesOnActivated)
+			{
+				_showReleaseNotesOnActivated = false;
+				using (var dlg = new ShowReleaseNotesDialog(Icon, FileLocationUtilities.GetFileDistributedWithApplication("releaseNotes.md")))
+				{
+					dlg.ShowDialog(this);
+				}
+			}
 			_recordingToolControl1.StartFilteringMessages();
 			_recordingToolControl1.MicCheckingEnabled = true;
 		}

--- a/src/Installer/Bootstrapper/HearThis Bootstrap Installer.wxs
+++ b/src/Installer/Bootstrapper/HearThis Bootstrap Installer.wxs
@@ -29,7 +29,8 @@
 				LogoFile ="logo.png"
 				ShowVersion="yes"
 				SuppressOptionsUI="yes"
-				LaunchTarget="[ProgramFiles64Folder]HearThis\HearThis.exe"/>
+				LaunchTarget="[ProgramFiles64Folder]HearThis\HearThis.exe"
+				LaunchArguments="-afterInstall"/>
 		</BootstrapperApplicationRef>
 		<Chain>
 		


### PR DESCRIPTION
Sadly, this required a hack.
Also reverted to showing release notes only when launched from Installer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/163)
<!-- Reviewable:end -->
