### PR TITLE
HT-371: Revert inclusion of System.ValueTuple.dll in Installer

### DIFF
--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -161,10 +161,6 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 			<File Id="ParatextData.dll" Name="ParatextData.dll" KeyPath="yes" Source="..\..\output\$(var.config)\ParatextData.dll" />
 		  </Component>
 
-          <Component Id="System.ValueTuple.dll" Guid="*">
-            <File Id="System.ValueTuple.dll" Name="System.ValueTuple.dll" KeyPath="yes" Source="..\..\output\$(var.config)\System.ValueTuple.dll" />
-          </Component>
-
 		  <Component Id="Microsoft.Extensions.DependencyModel.dll" Guid="*" Win64="yes">
 			<File Id="Microsoft.Extensions.DependencyModel.dll" Name="Microsoft.Extensions.DependencyModel.dll" KeyPath="yes" Source="..\..\output\$(var.config)\Microsoft.Extensions.DependencyModel.dll" />
 		  </Component>
@@ -298,7 +294,6 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 	  <ComponentRef Id="NAudio.dll"/>
 	  <ComponentRef Id="NetSparkle.Net40.dll"/>
 	  <ComponentRef Id="ParatextData.dll"/>          <!-- Needed for Paratext access -->
-	  <ComponentRef Id="System.ValueTuple.dll"/>     <!-- Needed for Paratext access -->
 	  <ComponentRef Id="Microsoft.Extensions.DependencyModel.dll"/> <!-- Needed for Paratext access -->
 	  <ComponentRef Id="Microsoft.Win32.Registry.dll"/>
 	  <ComponentRef Id="PtxUtils.dll"/>          <!-- Needed for Paratext access -->


### PR DESCRIPTION
Since this is included in .Net Framework 4.7 and later and this version of HearThis targets 4.7.2, it is not needed.
This reverts commit cdcf835c15a607f2ef61c9e14d84d319475883a5, reversing
changes made to b0e79d4028d66986d65e9c018414176a7bc2f849.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/167)
<!-- Reviewable:end -->
