### PR TITLE
Added logging and other minor enhancements

### DIFF
--- a/src/HearThis/Communication/AndroidSynchronization.cs
+++ b/src/HearThis/Communication/AndroidSynchronization.cs
@@ -18,7 +18,7 @@ namespace HearThis.Communication
 	public static class AndroidSynchronization
 	{
 		private const string kHearThisAndroidProductName = "HearThis Android";
-		public static void DoAndroidSync(Project project)
+		public static void DoAndroidSync(Project project, Form parent)
 		{
 			if (!project.IsRealProject)
 			{
@@ -88,7 +88,7 @@ namespace HearThis.Communication
 					}
 				}
 			};
-			dlg.Show();
+			dlg.Show(parent);
 		}
 	}
 }

--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -1,7 +1,7 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright (c) 2020, SIL International. All Rights Reserved.
-// <copyright from='2011' to='2020' company='SIL International'>
-//		Copyright (c) 2020, SIL International. All Rights Reserved.
+#region // Copyright (c) 2021, SIL International. All Rights Reserved.
+// <copyright from='2011' to='2021' company='SIL International'>
+//		Copyright (c) 2021, SIL International. All Rights Reserved.
 //
 //		Distributable under the terms of the MIT License (https://sil.mit-license.org/)
 // </copyright>
@@ -88,6 +88,7 @@ namespace HearThis
 			Settings.Default.AllowDisplayOfShiftClipsMenu = false;
 
 			SetUpErrorHandling();
+			Logger.Init();
 			SettingsProtectionSingleton.ProductSupportUrl = kSupportUrlSansHttps;
 			SetupLocalization();
 
@@ -234,6 +235,7 @@ namespace HearThis
 					.Where(m => m.Name == "GetString"),
 				"SIL.Windows.Forms.*", "SIL.DblBundle");
 			Settings.Default.UserInterfaceLanguage = LocalizationManager.UILanguageId;
+			Logger.WriteEvent("Initial UI language: " + LocalizationManager.UILanguageId);
 		}
 
 		/// <summary>

--- a/src/HearThis/Script/ScriptProviderBase.cs
+++ b/src/HearThis/Script/ScriptProviderBase.cs
@@ -114,6 +114,7 @@ namespace HearThis.Script
 
 		protected void Initialize(Action preDataMigrationInitializer = null)
 		{
+			Logger.WriteEvent("Initializing script provider for " + ProjectFolderName);
 			if (_skipFilePath != null)
 				throw new InvalidOperationException("Initialize should only be called once!");
 
@@ -141,6 +142,8 @@ namespace HearThis.Script
 		private void LoadProjectSettings(bool existingHearThisProject)
 		{
 			Debug.Assert(_projectSettings == null);
+
+			Logger.WriteEvent("Loading project settings for " + (existingHearThisProject ? "existing" : "new") + " project.");
 
 			_projectSettingsFilePath = Path.Combine(ProjectFolderPath, kProjectInfoFilename);
 			if (File.Exists(_projectSettingsFilePath))
@@ -171,11 +174,13 @@ namespace HearThis.Script
 				switch (_projectSettings.Version)
 				{
 					case 0:
+						Logger.WriteEvent($"Migrating {ProjectFolderName} to version 1.");
 						// This corrects data in a bogus state by having recorded clips for blocks
 						// marked with a skipped style.
 						BackupAnyClipsForSkippedStyles();
 						break;
 					case 1:
+						Logger.WriteEvent($"Migrating {ProjectFolderName} to version 2.");
 						// Original projects always broke at paragraphs,
 						// but now the default is to keep them together.
 						// This ensures we don't mess up existing recordings.
@@ -185,6 +190,7 @@ namespace HearThis.Script
 					case 2:
 						if (!_projectSettings.NewlyCreatedSettingsForExistingProject)
 						{
+							Logger.WriteEvent($"Migrating {ProjectFolderName} to version 3.");
 							// Settings that used to be per-user really should be per-project.
 							_projectSettings.BreakQuotesIntoBlocks = Settings.Default.BreakQuotesIntoBlocks;
 							_projectSettings.ClauseBreakCharacters = Settings.Default.ClauseBreakCharacters;
@@ -192,6 +198,7 @@ namespace HearThis.Script
 						}
 						break;
 					case 3:
+						Logger.WriteEvent($"Migrating {ProjectFolderName} to version 4.");
 						// HT-376: Unfortunately, HT v. 2.0.3 introduced a change whereby the numbering of
 						// existing clips could be out of sync with the data, so any chapter with one of the
 						// new StylesToSkipByDefault that has not had anything recorded since the

--- a/src/HearThis/UI/RecordInPartsDlg.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.cs
@@ -359,6 +359,7 @@ namespace HearThis.UI
 
 		protected override void OnLoad(EventArgs e)
 		{
+			Logger.WriteEvent("Recording in parts");
 			Settings.Default.RecordInPartsFormSettings.InitializeForm(this);
 			base.OnLoad(e);
 			UpdateDisplay();

--- a/src/HearThis/UI/Shell.Designer.cs
+++ b/src/HearThis/UI/Shell.Designer.cs
@@ -108,6 +108,7 @@ namespace HearThis.UI
 			this._uiLanguageMenu.Size = new System.Drawing.Size(58, 20);
 			this._uiLanguageMenu.Text = "English";
 			this._uiLanguageMenu.ToolTipText = "User-interface Language";
+			this._uiLanguageMenu.DropDownOpening += new System.EventHandler(this.MenuDropDownOpening);
 			// 
 			// _btnMode
 			// 
@@ -173,6 +174,7 @@ namespace HearThis.UI
 			this._moreMenu.Name = "_moreMenu";
 			this._moreMenu.Size = new System.Drawing.Size(48, 20);
 			this._moreMenu.Text = "More";
+			this._moreMenu.DropDownOpening += new System.EventHandler(this.MenuDropDownOpening);
 			// 
 			// _settingsItem
 			// 
@@ -227,7 +229,7 @@ namespace HearThis.UI
 			this._mergeHearthisPackItem.Name = "_mergeHearthisPackItem";
 			this._mergeHearthisPackItem.Size = new System.Drawing.Size(194, 22);
 			this._mergeHearthisPackItem.Text = "Merge HearThis Pack...";
-			this._mergeHearthisPackItem.Click += new System.EventHandler(this._mergeHearthisPackItem_Click);
+			this._mergeHearthisPackItem.Click += new System.EventHandler(this._mergeHearThisPackItem_Click);
 			// 
 			// _saveHearthisPackItem
 			// 
@@ -237,7 +239,7 @@ namespace HearThis.UI
 			this._saveHearthisPackItem.Name = "_saveHearthisPackItem";
 			this._saveHearthisPackItem.Size = new System.Drawing.Size(194, 22);
 			this._saveHearthisPackItem.Text = "Save HearThis Pack...";
-			this._saveHearthisPackItem.Click += new System.EventHandler(this._saveHearthisPackItem_Click);
+			this._saveHearthisPackItem.Click += new System.EventHandler(this._saveHearThisPackItem_Click);
 			// 
 			// toolStripMenuItem4
 			// 

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -229,6 +229,7 @@ namespace HearThis.UI
 				{
 					LocalizationManager.SetUILanguage(languageId, true);
 					Settings.Default.UserInterfaceLanguage = languageId;
+					Logger.WriteEvent("UI language changed: " + languageId);
 					item.Select();
 					_uiLanguageMenu.Text = ((L10NCultureInfo) item.Tag).NativeName;
 				});
@@ -309,6 +310,7 @@ namespace HearThis.UI
 		{
 			using (var dlg = new PublishDialog(Project))
 			{
+				Logger.WriteEvent("Showing export dialog box.");
 				dlg.ShowDialog();
 			}
 		}
@@ -323,6 +325,7 @@ namespace HearThis.UI
 			{
 				using (var dlg = new AdministrativeSettings(Project))
 				{
+					Logger.WriteEvent("Showing settings dialog box.");
 					return dlg.ShowDialog(FindForm());
 				}
 			});
@@ -362,6 +365,7 @@ namespace HearThis.UI
 			{
 				dlg.CheckForUpdatesClicked += HandleAboutDialogCheckForUpdatesClick;
 				dlg.ReleaseNotesClicked += HandleAboutDialogReleaseNotesClicked;
+				Logger.WriteEvent("Showing About dialog box.");
 				dlg.ShowDialog();
 			}
 		}
@@ -404,6 +408,7 @@ namespace HearThis.UI
 			if (ActiveForm == this)
 			{
 				Application.Idle -= ShowReleaseNotesWhenActiveAndIdle;
+				Logger.WriteEvent("Displaying release notes on idle after install.");
 				using (var dlg = new ShowReleaseNotesDialog(Icon, FileLocationUtilities.GetFileDistributedWithApplication("releaseNotes.md")))
 					dlg.ShowDialog(this);
 			}
@@ -418,6 +423,7 @@ namespace HearThis.UI
 
 		private bool LoadProject(string name)
 		{
+			Logger.WriteEvent("Loading project " + name);
 			try
 			{
 				_projectNameToShow = name;
@@ -535,6 +541,7 @@ namespace HearThis.UI
 						using (var dlg = new DataMigrationReportNagDlg(Project.ProjectSettings.LastDataMigrationReportNag, dataMigrationReportFilename,
 							ScriptProviderBase.GetUrlForHelpWithDataMigrationProblem(Project.ProjectSettings.LastDataMigrationReportNag)))
 						{
+							Logger.WriteEvent("Showing Data Migration Report nag dialog box.");
 							dlg.ShowDialog(this);
 							clearNag = dlg.StopNagging;
 							if (dlg.DeleteReportFile)
@@ -688,7 +695,7 @@ namespace HearThis.UI
 
 		private void _syncWithAndroidItem_Click(object sender, EventArgs e)
 		{
-			AndroidSynchronization.DoAndroidSync(Project);
+			AndroidSynchronization.DoAndroidSync(Project, this);
 		}
 		private void Shell_ResizeEnd(object sender, EventArgs e)
 		{
@@ -775,43 +782,49 @@ namespace HearThis.UI
 			_actorCharacterButton_Click(sender, e);
 		}
 
-		private void _saveHearthisPackItem_Click(object sender, EventArgs e)
+		private void _saveHearThisPackItem_Click(object sender, EventArgs e)
 		{
 			bool limitToActor = false;
 			using (var htDlg = new SaveHearThisPackDlg())
 			{
 				htDlg.Actor = Project.ActorCharacterProvider?.Actor;
+				Logger.WriteEvent("Showing SaveHearThisPack dialog box");
 				if (htDlg.ShowDialog(this) != DialogResult.OK)
 					return;
 				limitToActor = htDlg.LimitToActor;
 			}
-			var dlg = new SaveFileDialog();
-			dlg.Filter = HearThisPackFilter;
-			dlg.RestoreDirectory = true;
-			if (dlg.ShowDialog() != DialogResult.OK || IsNullOrEmpty(dlg.FileName))
-				return;
-			var packer = new HearThisPackMaker(Project.ProjectFolder);
-			if (limitToActor && Project.ActorCharacterProvider != null)
-				packer.Actor = Project.ActorCharacterProvider.Actor;
-			var progressDlg = new MergeProgressDialog();
-			// See comment in merge...dialog will close when user clicks OK AFTER this method returns.
-			progressDlg.Closed += (o, args) => progressDlg.Dispose();
-			progressDlg.SetSource(Path.GetFileName(dlg.FileName));
-			progressDlg.Show(this);
-			// Enhance: is it worth having the message indicate whether we are restricting to actor?
-			// If it didn't mean yet another message to localize I would.
-			progressDlg.SetLabel(Format(LocalizationManager.GetString("MainWindow.SavingTo", "Saving to {0}", "Keep {0} as a placeholder for the file name")
-				, Path.GetFileName(dlg.FileName)));
-			progressDlg.Text = Format(LocalizationManager.GetString("MainWindow.SavingHearThisPack", "Saving {0}", "{0} will be the file extension, HearThisPack"), "HearThisPack");
-			packer.Pack(dlg.FileName, progressDlg.LogBox);
-			progressDlg.LogBox.WriteMessage(Format(LocalizationManager.GetString("MainWindow.PackComplete", "{0} is complete--click OK to close this window"), "HearThisPack"));
-			progressDlg.SetDone();
+
+			using (var dlg = new SaveFileDialog())
+			{
+				dlg.Filter = HearThisPackFilter;
+				dlg.RestoreDirectory = true;
+				if (dlg.ShowDialog() != DialogResult.OK || IsNullOrEmpty(dlg.FileName))
+					return;
+
+				var packer = new HearThisPackMaker(Project.ProjectFolder);
+				if (limitToActor && Project.ActorCharacterProvider != null)
+					packer.Actor = Project.ActorCharacterProvider.Actor;
+				var progressDlg = new MergeProgressDialog();
+				// See comment in merge...dialog will close when user clicks OK AFTER this method returns.
+				progressDlg.Closed += (o, args) => progressDlg.Dispose();
+				progressDlg.SetSource(Path.GetFileName(dlg.FileName));
+				progressDlg.Show(this);
+				// Enhance: is it worth having the message indicate whether we are restricting to actor?
+				// If it didn't mean yet another message to localize I would.
+				progressDlg.SetLabel(Format(LocalizationManager.GetString("MainWindow.SavingTo", "Saving to {0}", "Keep {0} as a placeholder for the file name")
+					, Path.GetFileName(dlg.FileName)));
+				progressDlg.Text = Format(LocalizationManager.GetString("MainWindow.SavingHearThisPack", "Saving {0}", "{0} will be the file extension, HearThisPack"), "HearThisPack");
+				packer.Pack(dlg.FileName, progressDlg.LogBox);
+
+				progressDlg.LogBox.WriteMessage(Format(LocalizationManager.GetString("MainWindow.PackComplete", "{0} is complete--click OK to close this window"), "HearThisPack"));
+				progressDlg.SetDone();
+			}
 		}
 
 		private static string HearThisPackFilter => @"HearThisPack files (*" + HearThisPackMaker.HearThisPackExtension + @")|*" +
 		                                            HearThisPackMaker.HearThisPackExtension;
 
-		private void _mergeHearthisPackItem_Click(object sender, EventArgs e)
+		private void _mergeHearThisPackItem_Click(object sender, EventArgs e)
 		{
 			var dlg = new OpenFileDialog();
 			dlg.Filter = HearThisPackFilter;
@@ -823,16 +836,19 @@ namespace HearThis.UI
 			{
 				if (reader.ProjectName.ToLowerInvariant() != Project.Name.ToLowerInvariant())
 				{
-					var msg = LocalizationManager.GetString("MainWindow.MergeNoData",
+					var msg = Format(LocalizationManager.GetString("MainWindow.MergeNoData",
 						"This HearThis pack does not have any data for {0}. It contains data for {1}. If you want to merge it please open that project.",
-						"Keep {0} as a placeholder for the current project name, {1} for the project in the file");
+						"Keep {0} as a placeholder for the current project name, {1} for the project in the file"), Project.Name, reader.ProjectName);
+					Logger.WriteEvent(msg);
 					MessageBox.Show(this,
-						Format(msg, Project.Name, reader.ProjectName),
+						msg,
 						LocalizationManager.GetString("MainWindow.MergeWrongProject", "Wrong Project"),
 						MessageBoxButtons.OK,
 						MessageBoxIcon.Warning);
 					return;
 				}
+
+				Logger.WriteEvent("Merging HearThis Pack: " + dlg.FileName);
 				var packLink = reader.GetLink();
 				var ourLink = new WindowsLink(Program.ApplicationDataBaseFolder);
 				var merger = new RepoMerger(Project, ourLink, packLink);
@@ -856,6 +872,26 @@ namespace HearThis.UI
 		private void supportToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			Process.Start($"https://{Program.kSupportUrlSansHttps}");
+		}
+
+		private void MenuDropDownOpening(object sender, EventArgs e)
+		{
+			var menuItem = sender as ToolStripDropDownButton;
+			if (menuItem == null || menuItem.HasDropDownItems == false)
+				return; // not a drop down item
+
+			// Current bounds of the current monitor
+			var upperRightCornerOfMenuInScreenCoordinates = menuItem.GetCurrentParent().PointToScreen(new Point(menuItem.Bounds.Right, menuItem.Bounds.Top));
+			var currentScreen = Screen.FromPoint(upperRightCornerOfMenuInScreenCoordinates);
+
+			// Get width of widest child item (skip separators!)
+			var maxWidth = menuItem.DropDownItems.OfType<ToolStripMenuItem>().Select(m => m.Width).Max();
+
+			var farRight = upperRightCornerOfMenuInScreenCoordinates.X + maxWidth;
+			var currentMonitorRight = currentScreen.Bounds.Right;
+
+			menuItem.DropDownDirection = farRight > currentMonitorRight ? ToolStripDropDownDirection.Left :
+				ToolStripDropDownDirection.Right;
 		}
 	}
 }

--- a/src/HearThis/UI/UpgradeNeededDialog.cs
+++ b/src/HearThis/UI/UpgradeNeededDialog.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using SIL.Reporting;
 
 namespace HearThis.UI
 {
@@ -12,6 +13,12 @@ namespace HearThis.UI
 		public UpgradeNeededDialog()
 		{
 			InitializeComponent();
+		}
+
+		protected override void OnShown(EventArgs e)
+		{
+			Logger.WriteEvent("Showing Upgrade Needed dialog box.");
+			base.OnShown(e);
 		}
 
 		private void btnCheckForUpdates_Click(object sender, EventArgs e)


### PR DESCRIPTION
Logging was previously used minimally but never properly initialized.
Added Logger calls to try to get more info about HT-398

Added MenuDropDownOpening to ensure dropdown menus display on correct screen
Fixed some type case typos in identifiers
Made Android Sync window appear on same screen as HearThis main window.
Added using for use of SaveFileDialog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/188)
<!-- Reviewable:end -->
