### PR TITLE
HT-400: Fixed problem with HearThis being launched both by NetSparkle and by the Installer

### DIFF
--- a/src/HearThis/Script/ChapterInfo.cs
+++ b/src/HearThis/Script/ChapterInfo.cs
@@ -273,8 +273,7 @@ namespace HearThis.Script
 				// correct information in it, this is a core HearThis data file. If we
 				// can't save it for some reason, the problem probably isn't going to
 				// magically go away.
-				ErrorReport.ReportFatalException(error);
-				throw error;
+				throw new Exception("Unable to save file: " + filePath, error);
 			}
 		}
 

--- a/src/HearThis/Script/MigrationProgressTracker.cs
+++ b/src/HearThis/Script/MigrationProgressTracker.cs
@@ -130,7 +130,7 @@ namespace HearThis.Script
 				Logger.WriteError(error);
 				Logger.WriteEvent("MigrationProgressTracker state at time of failure:" + Environment.NewLine +
 					XmlSerializationHelper.SerializeToString(this, true));
-				ErrorReport.ReportFatalException(error);
+				throw new Exception("Unable to save mogration progress file: " + _filename, error);
 			}
 		}
 

--- a/src/HearThis/Script/ScriptProviderBase.cs
+++ b/src/HearThis/Script/ScriptProviderBase.cs
@@ -225,7 +225,7 @@ namespace HearThis.Script
 				Logger.WriteError(error);
 				Logger.WriteEvent("Settings:" + Environment.NewLine +
 					XmlSerializationHelper.SerializeToString(_projectSettings, true));
-				ErrorReport.ReportFatalException(error);
+				throw new Exception("Unable to save file: " + _projectSettingsFilePath, error);
 			}
 		}
 

--- a/src/HearThis/Script/SkippedScriptLines.cs
+++ b/src/HearThis/Script/SkippedScriptLines.cs
@@ -137,7 +137,7 @@ namespace HearThis.Script
 			if (!XmlSerializationHelper.SerializeToFile(skipFilePath, this, out var error))
 			{
 				Logger.WriteError(error);
-				ErrorReport.ReportFatalException(error);
+				throw new Exception("Unable to write file: " + skipFilePath, error);
 			}
 		}
 

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -1055,8 +1055,12 @@ namespace HearThis.UI
 		private void SetZoom(float newZoom)
 		{
 			var zoom = Math.Max(Math.Min(newZoom, 2.0f), 1.0f);
-			Settings.Default.ZoomFactor = zoom;
-			Settings.Default.Save();
+			if (Settings.Default.ZoomFactor != zoom)
+			{
+				Settings.Default.ZoomFactor = zoom;
+				Settings.Default.Save();
+			}
+
 			_scriptControl.ZoomFactor = zoom;
 		}
 

--- a/src/HearThis/UI/ScriptControl.cs
+++ b/src/HearThis/UI/ScriptControl.cs
@@ -429,9 +429,11 @@ namespace HearThis.UI
 
 		public float ZoomFactor
 		{
-			get { return _zoomFactor; }
+			get => _zoomFactor;
 			set
 			{
+				if (_zoomFactor.Equals(value))
+					return;
 				_zoomFactor = value;
 				Invalidate();
 			}

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -168,6 +168,7 @@ namespace HearThis.UI
 
 			UpdateChecker = new Sparkle(@"https://build.palaso.org/guestAuth/repository/download/HearThis_HearThisWinDevPublishPt8/.lastSuccessful/appcast.xml",
 				Icon);
+			UpdateChecker.DoLaunchAfterUpdate = false; // The HearThis installer already takes care of launching.
 			// We don't want to do this until the main window is loaded because a) it's very easy for the user to overlook, and b)
 			// more importantly, when the toast notifier closes, it can sometimes clobber an error message being displayed for the user.
 			UpdateChecker.CheckOnFirstApplicationIdle();


### PR DESCRIPTION
This causes various file contention problems: HT-271, HT-276, HT-288, HT-378, HT-380, HT-400
Also changed error handling when writing XML files to get a more complete call stack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/191)
<!-- Reviewable:end -->
