### PR TITLE
HT-415: Implemented a hack to allow HearThis to continue to load Para…

### DIFF
--- a/src/HearThis/Script/ParatextParagraph.cs
+++ b/src/HearThis/Script/ParatextParagraph.cs
@@ -165,13 +165,22 @@ namespace HearThis.Script
 			//              Debug.WriteLine("Start " + State.Marker + " bold=" + State.Bold + " center=" + State.JustificationType);
 		}
 
-		private class HearThisDummyPara : IScrParserState
+		/// <summary>
+		/// Represents a "dummy" parser state in order to be able to force a simulated paragraph
+		/// into the data stream where it is missing in the actual data coming from Paratext.
+		/// HearThis doesn't really care that much about paragraphs, but the paragraph that
+		/// contains potentially recordable text does tell it a) whether it is a Scripture Heading
+		/// (often omitted from recordings) and b) what the base font face, style and size are for
+		/// the text. As such, HearThis can't accommodate text not contained by a paragraph.
+		/// </summary>
+		/// <remarks>
+		/// Normally, IScrParserState is implemented by an object that wraps a Paratext
+		/// ScrParserState object, with its properties determined by the preceding markers in the
+		/// stream.
+		/// </remarks>
+		private class HearThisDummyParaState : IScrParserState
 		{
-
-			public HearThisDummyPara(ScrTag paraTag)
-			{
-				ParaTag = paraTag;
-			}
+			public HearThisDummyParaState(ScrTag paraTag) => ParaTag = paraTag;
 
 			public ScrTag NoteTag => null;
 
@@ -189,10 +198,11 @@ namespace HearThis.Script
 			}
 		}
 
+		// HT-415: this is (as the name implies) a hack to allow HearThis
+		// to load a Paratext book that is missing paragraph markers after the \c.
 		internal void ForceNewParagraph(ScrTag paraTag)
 		{
-			IScrParserState scrParserState = new HearThisDummyPara(paraTag);
-			StartNewParagraph(scrParserState, false);
+			StartNewParagraph(new HearThisDummyParaState(paraTag), false);
 		}
 
 		/// <summary>

--- a/src/HearThis/Script/ParatextParagraph.cs
+++ b/src/HearThis/Script/ParatextParagraph.cs
@@ -1,7 +1,7 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright (c) 2020, SIL International. All Rights Reserved.
-// <copyright from='2011' to='2020' company='SIL International'>
-//		Copyright (c) 2020, SIL International. All Rights Reserved.
+#region // Copyright (c) 2022, SIL International. All Rights Reserved.
+// <copyright from='2011' to='2022' company='SIL International'>
+//		Copyright (c) 2022, SIL International. All Rights Reserved.
 //
 //		Distributable under the terms of the MIT License (https://sil.mit-license.org/)
 // </copyright>
@@ -163,6 +163,36 @@ namespace HearThis.Script
 			_finalLineNumber0Based = _initialLineNumber0Based;
 
 			//              Debug.WriteLine("Start " + State.Marker + " bold=" + State.Bold + " center=" + State.JustificationType);
+		}
+
+		private class HearThisDummyPara : IScrParserState
+		{
+
+			public HearThisDummyPara(ScrTag paraTag)
+			{
+				ParaTag = paraTag;
+			}
+
+			public ScrTag NoteTag => null;
+
+			public ScrTag CharTag => null;
+
+			public ScrTag ParaTag { get; }
+
+			public bool ParaStart => true;
+
+			public bool IsPublishable => true;
+
+			public void UpdateState(List<UsfmToken> tokenList, int tokenIndex)
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		internal void ForceNewParagraph(ScrTag paraTag)
+		{
+			IScrParserState scrParserState = new HearThisDummyPara(paraTag);
+			StartNewParagraph(scrParserState, false);
 		}
 
 		/// <summary>

--- a/src/HearThis/Script/ParatextScriptProvider.cs
+++ b/src/HearThis/Script/ParatextScriptProvider.cs
@@ -1,7 +1,7 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright (c) 2021, SIL International. All Rights Reserved.
-// <copyright from='2011' to='2021' company='SIL International'>
-//		Copyright (c) 2021, SIL International. All Rights Reserved.
+#region // Copyright (c) 2022, SIL International. All Rights Reserved.
+// <copyright from='2011' to='2022' company='SIL International'>
+//		Copyright (c) 2022, SIL International. All Rights Reserved.
 //
 //		Distributable under the terms of the MIT License (https://sil.mit-license.org/)
 // </copyright>
@@ -298,9 +298,17 @@ namespace HearThis.Script
 							{
 								lookingForVerseText = false;
 								versesPerChapter[currentChapter1Based]++;
+
+								if (paragraph.State == null && _paratextProject is ParatextScripture ptProject)
+								{
+									// HT-415: this is (as the name implies) a hack to allow HearThis
+									// to load a Paratext book that is missing paragraph markers after the \c.
+									paragraph.ForceNewParagraph(ptProject.DefaultScriptureParaTag);
+								}
 							}
 							if (inTitle && paragraph.HasData)
 								paragraph.AddHardLineBreak();
+
 							paragraph.Add(tokenText);
 						}
 						break;

--- a/src/HearThis/UI/ParatextScripture.cs
+++ b/src/HearThis/UI/ParatextScripture.cs
@@ -1,7 +1,7 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright (c) 2020, SIL International. All Rights Reserved.
-// <copyright from='2011' to='2020' company='SIL International'>
-//		Copyright (c) 2020, SIL International. All Rights Reserved.
+#region // Copyright (c) 2022, SIL International. All Rights Reserved.
+// <copyright from='2011' to='2022' company='SIL International'>
+//		Copyright (c) 2022, SIL International. All Rights Reserved.
 //
 //		Distributable under the terms of the MIT License (https://sil.mit-license.org/)
 // </copyright>
@@ -34,6 +34,12 @@ namespace HearThis.Script
 		#region IScripture Members
 
 		public ScrVers Versification => _scrText.Settings.Versification;
+
+		// HT-415: This is a hack to allow HearThis to load a Paratext book that
+		// is missing paragraph markers after the \c. We can't really know
+		// which paragraph style to use, but "\p" is the most common and since it
+		// typically doesn't matter (unless the text was supposed to be a heading).
+		public ScrTag DefaultScriptureParaTag => _scrText.DefaultStylesheet.GetTag("p");
 
 		public List<UsfmToken> GetUsfmTokens(VerseRef verseRef)
 		{


### PR DESCRIPTION
…text data with missing paragraph markers following \c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/202)
<!-- Reviewable:end -->
