### PR TITLE
Prevent continued playback of files in RecordInPartsDlg once dialog is closed

### DIFF
--- a/DistFiles/localization/HearThis.es.xlf
+++ b/DistFiles/localization/HearThis.es.xlf
@@ -167,6 +167,12 @@
         <note>Localize the tooltip, not the button name</note>
         <target xml:lang="es-ES" state="translated">Reproducir el clip grabado para este bloque (tecla Tab)</target>
       </trans-unit>
+      <trans-unit id="AudioButtonsControl.PlaybackProblem">
+        <source xml:lang="en">There was a problem playing clip {0} (block {1}) for {2} {3}.</source>
+        <note>ID: AudioButtonsControl.PlaybackProblem</note>
+        <note>Param 0: clip file number; Param 1: block number; Param 2: Scripture book name; Param 3: chapter number</note>
+        <target xml:lang="es-ES" state="translated">Hubo un problema al reproducir el clip {0} (bloque {1}) de {2} {3}.</target>
+      </trans-unit>
       <trans-unit id="AudioButtonsControl.PleaseHold" approved="yes">
         <source xml:lang="en">Hold down the record button (or the space bar) while talking, and only let it go when you're done.</source>
         <note>ID: AudioButtonsControl.PleaseHold</note>
@@ -178,11 +184,6 @@
         <note>ID: AudioButtonsControl.PressToRecord</note>
         <note>Caption for HoldButtonHint message</note>
         <target xml:lang="es-ES" state="translated">Presionar para grabar</target>
-      </trans-unit>
-      <trans-unit id="AudioButtonsControl.ReadingProblem">
-        <source xml:lang="en">There was a problem reading that file. Try again later.</source>
-        <note>ID: AudioButtonsControl.ReadingProblem</note>
-        <target xml:lang="es-ES" state="translated">Hubo un problema leyendo el archivo. Inténtalo más tarde.</target>
       </trans-unit>
       <trans-unit id="AudioButtonsControl.RecordButton.ToolTip_">
         <source xml:lang="en">Record this block. (Press and hold the mouse or the Space Bar.)</source>

--- a/DistFiles/localization/HearThis.fr.xlf
+++ b/DistFiles/localization/HearThis.fr.xlf
@@ -146,6 +146,12 @@
         <note>Localize the tooltip, not the button name</note>
         <target xml:lang="fr" state="translated">Lire le clip enregistré pour ce bloc (touche Tab)</target>
       </trans-unit>
+      <trans-unit id="AudioButtonsControl.PlaybackProblem">
+        <source xml:lang="en">There was a problem playing clip {0} (block {1}) for {2} {3}.</source>
+        <note>ID: AudioButtonsControl.PlaybackProblem</note>
+        <note>Param 0: clip file number; Param 1: block number; Param 2: Scripture book name; Param 3: chapter number</note>
+        <target xml:lang="fr" state="translated">Il y a eu un problème lors de la lecture du clip {0} (bloc {1}) pour {2} {3}.</target>
+      </trans-unit>
       <trans-unit id="AudioButtonsControl.PleaseHold">
         <source xml:lang="en">Hold down the record button (or the space bar) while talking, and only let it go when you're done.</source>
         <note>ID: AudioButtonsControl.PleaseHold</note>
@@ -157,11 +163,6 @@
         <note>ID: AudioButtonsControl.PressToRecord</note>
         <note>Caption for HoldButtonHint message</note>
         <target xml:lang="fr" state="translated">Appuyer sur pour enregistrer</target>
-      </trans-unit>
-      <trans-unit id="AudioButtonsControl.ReadingProblem">
-        <source xml:lang="en">There was a problem reading that file. Try again later.</source>
-        <note>ID: AudioButtonsControl.ReadingProblem</note>
-        <target xml:lang="fr" state="translated">Il y a eu un problème pour lire ce fichier. Veuillez réessayer plus tard.</target>
       </trans-unit>
       <trans-unit id="AudioButtonsControl.RecordButton.ToolTip_">
         <source xml:lang="en">Record this block. (Press and hold the mouse or the Space Bar.)</source>

--- a/DistFiles/localization/HearThis.pt.xlf
+++ b/DistFiles/localization/HearThis.pt.xlf
@@ -207,10 +207,6 @@
         <note>ID: AudioButtonsControl.PressToRecord</note>
         <note>Caption for HoldButtonHint message</note>
       </trans-unit>
-      <trans-unit id="AudioButtonsControl.ReadingProblem">
-        <source xml:lang="en">There was a problem reading that file. Try again later.</source>
-        <note>ID: AudioButtonsControl.ReadingProblem</note>
-      </trans-unit>
       <trans-unit id="AudioButtonsControl.RecordButton.ToolTip_">
         <source xml:lang="en">Record this block. (Press and hold the mouse or the Space Bar.)</source>
         <target xml:lang="pt">Grava este bloco. (Deixa pressionado o botão ou barra de espaço.)</target>

--- a/src/HearThis/UI/AudioButtonsControl.cs
+++ b/src/HearThis/UI/AudioButtonsControl.cs
@@ -442,8 +442,18 @@ namespace HearThis.UI
 				catch (Exception err)
 				{
 					_playButton.Playing = false; //normally, this is done in the stopped event handler
+					var clipNum = System.IO.Path.GetFileNameWithoutExtension(Path);
+					var folder = System.IO.Path.GetDirectoryName(Path);
+					var chapter = System.IO.Path.GetFileName(folder);
+					folder = System.IO.Path.GetDirectoryName(folder);
+					var book = System.IO.Path.GetFileName(folder);
 					ErrorReport.NotifyUserOfProblem(err,
-						LocalizationManager.GetString("AudioButtonsControl.ReadingProblem", "There was a problem reading that file. Try again later."));
+						LocalizationManager.GetString("AudioButtonsControl.PlaybackProblem",
+							"There was a problem playing clip {0} (block {1}) for {2} {3}.",
+							"Param 0: clip file number; " +
+							"Param 1: block number; " +
+							"Param 2: Scripture book name; " +
+							"Param 3: chapter number"), clipNum, int.Parse(clipNum) + 1, book, chapter);
 				}
 			}
 

--- a/src/HearThis/UI/RecordInPartsDlg.cs
+++ b/src/HearThis/UI/RecordInPartsDlg.cs
@@ -9,6 +9,7 @@
 // --------------------------------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -393,6 +394,18 @@ namespace HearThis.UI
 			_instructionsLabel.ForeColor = (newState == BtnState.MouseOver) ?
 				AppPalette.ScriptContextTextColorDuringRecording :
 				_defaultForegroundColorForInstructions;
+		}
+
+		protected override void OnClosed(EventArgs e)
+		{
+			// Stop playback to release the temp files, and dispose the players, thus
+			// preventing them from raising a PlaybackStopped event after the control
+			// has been disposed.
+			_audioButtonsFirst.Path = null;
+			_audioButtonsSecond.Path = null;
+			_audioButtonsBoth.Path = null;
+
+			base.OnClosed(e);
 		}
 
 		private void _useRecordingsButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
I'm thinking that having the joined file open might be the cause of the occasional corrupt (0-byte) file we've seen reported from the field (e.g., HT-342)
HT-341: Improved wording of error message to make it possible to provide better support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/208)
<!-- Reviewable:end -->
