### PR TITLE
Fixed bug in OnScriptBlockRecorded for glyssenscript-based projects.

### DIFF
--- a/src/HearThis/Script/ChapterInfo.cs
+++ b/src/HearThis/Script/ChapterInfo.cs
@@ -284,7 +284,7 @@ namespace HearThis.Script
 		public override void OnScriptBlockRecorded(ScriptLine selectedScriptBlock)
 		{
 			var filename = ClipRepository.GetPathToLineRecording(_projectName, _bookName,
-				ChapterNumber1Based, selectedScriptBlock.Number - 1, _scriptProvider);
+				ChapterNumber1Based, selectedScriptBlock.Number - 1);
 			if (ClipRepository.IsInvalidClipFile(filename))
 				return;
 			selectedScriptBlock.Skipped = false;


### PR DESCRIPTION
We should not be passing the _scriptProvider in this call to GetPathToLineRecording because the line number is calculated based on the passed-in selectedScriptBlock, whose Number already correctly reflects the place in the unfiltered sequence of blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/213)
<!-- Reviewable:end -->
