### PR TITLE
Improved the way we track whether a restart was in response to a color scheme change

### DIFF
--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -85,8 +85,19 @@ namespace HearThis
 				showReleaseNotes = launchedFromInstaller;
 				Settings.Default.Save();
 			}
-			// As a safety measure, we always revert this advanced admin setting to false on restart.
-			Settings.Default.AllowDisplayOfShiftClipsMenu = false;
+			if (Settings.Default.RestartingToChangeColorScheme)
+			{
+				RestartedToChangeColorScheme = true;
+				Settings.Default.RestartingToChangeColorScheme = false;
+				Settings.Default.Save();
+			}
+			else if (Settings.Default.AllowDisplayOfShiftClipsMenu)
+			{
+				// As a safety measure, we always revert this advanced admin setting to false on restart
+				// unless restarting due to a color scheme change.
+				Settings.Default.AllowDisplayOfShiftClipsMenu = false;
+				Settings.Default.Save();
+			}
 
 			SetUpErrorHandling();
 			Logger.Init();
@@ -194,6 +205,8 @@ namespace HearThis
 				}
 			}
 		}
+
+		public static bool RestartedToChangeColorScheme { get; private set; }
 
 		public static IEnumerable<ErrorMessageInfo> CompatibleParatextProjectLoadErrors => ScrTextCollection.ErrorMessages.Where(e => e.ProjecType != ProjectType.Resource && !e.ProjecType.IsNoteType());
 

--- a/src/HearThis/Properties/Settings.Designer.cs
+++ b/src/HearThis/Properties/Settings.Designer.cs
@@ -419,12 +419,24 @@ namespace HearThis.Properties {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool AllowDisplayOfShiftClipsMenu {
-            get {
-                return ((bool)(this["AllowDisplayOfShiftClipsMenu"]));
-            }
-            set {
-                this["AllowDisplayOfShiftClipsMenu"] = value;
-            }
+	        get {
+		        return ((bool)(this["AllowDisplayOfShiftClipsMenu"]));
+	        }
+	        set {
+		        this["AllowDisplayOfShiftClipsMenu"] = value;
+	        }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RestartingToChangeColorScheme {
+	        get {
+		        return ((bool)(this["RestartingToChangeColorScheme"]));
+	        }
+	        set {
+		        this["RestartingToChangeColorScheme"] = value;
+	        }
         }
     }
 }

--- a/src/HearThis/Properties/Settings.settings
+++ b/src/HearThis/Properties/Settings.settings
@@ -104,5 +104,8 @@
     <Setting Name="CurrentSkippedLineVersion" Type="System.Int32" Scope="Application">
       <Value Profile="(Default)">2</Value>
     </Setting>
+    <Setting Name="RestartingToChangeColorScheme" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/HearThis/UI/AdministrativeSettings.cs
+++ b/src/HearThis/UI/AdministrativeSettings.cs
@@ -162,17 +162,14 @@ namespace HearThis.UI
 
 			// Save settings on Interface tab
 			Settings.Default.DisplayNavigationButtonLabels = _chkShowBookAndChapterLabels.Checked;
-			
+			Settings.Default.AllowDisplayOfShiftClipsMenu = _chkEnableClipShifting.Checked;
 			if (Settings.Default.UserColorScheme != (ColorScheme)_cboColorScheme.SelectedValue)
 			{
+				Settings.Default.RestartingToChangeColorScheme = true;
 				Settings.Default.UserColorScheme = (ColorScheme)_cboColorScheme.SelectedValue;
 				Settings.Default.Save();
 				Application.Restart();
 			}
-
-			// This will not be enabled if changing the color scheme because this setting always
-			// reverts to false on application restart.
-			Settings.Default.AllowDisplayOfShiftClipsMenu = _chkEnableClipShifting.Checked;
 		}
 
 #if MULTIPLEMODES
@@ -280,15 +277,6 @@ namespace HearThis.UI
 		{
 			lblColorSchemeChangeRestartWarning.Visible =
 				Settings.Default.UserColorScheme != (ColorScheme)_cboColorScheme.SelectedValue;
-
-			// If the user is changing the color scheme, a restart is required. Since we always
-			// re-disable the Shift Clips command (to prevent it accidentally being left on and
-			// having a naive user do something awful with it by accident) every time HearThis
-			// restarts, there's no point keeping this enabled (much less selected) because it
-			// won't survive the restart, and it will probably confuse or annoy the user.
-			_chkEnableClipShifting.Enabled =
-				Settings.Default.UserColorScheme == (ColorScheme)_cboColorScheme.SelectedValue;
-			_chkEnableClipShifting.Checked &= _chkEnableClipShifting.Enabled;
 		}
 
 		private void chkEnableClipShifting_CheckedChanged(object sender, EventArgs e)

--- a/src/HearThis/app.config
+++ b/src/HearThis/app.config
@@ -94,6 +94,9 @@
             <setting name="AllowDisplayOfShiftClipsMenu" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="RestartingToChangeColorScheme" serializeAs="String">
+                <value>False</value>
+            </setting>
         </HearThis.Properties.Settings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup>


### PR DESCRIPTION
This allows the shift clips feature to be turned on (and remain enabled) when changing the color scheme. (It will also make it easier to know when to do or not do other things in response to this kind of special restart.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/214)
<!-- Reviewable:end -->
