### PR TITLE
Removed .* from end of namespace spec in call to LocalizationManage.Create

### DIFF
--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -280,7 +280,7 @@ namespace HearThis
 				typeof(SIL.Localizer)
 					.GetMethods(BindingFlags.Static | BindingFlags.Public)
 					.Where(m => m.Name == "GetString"),
-				"SIL.Windows.Forms.*", "SIL.DblBundle");
+				"SIL.Windows.Forms", "SIL.DblBundle");
 			Settings.Default.UserInterfaceLanguage = LocalizationManager.UILanguageId;
 			Logger.WriteEvent("Initial UI language: " + LocalizationManager.UILanguageId);
 		}


### PR DESCRIPTION
I'm really mystified as to why/how the .* was ever added. We only put it on one of the two. Looking at the code in L10nSharp (see line 194 in StringExtractor.cs), I can't see how .* could ever have worked, and that code is essentially the same as it has been for at least 10 years. Oddly, I couldn't detect any difference between having and not having it, but I suspect that is because it just uses the checked-in version of the English xlf file rather than (or in addition to) scanning for new strings, and maybe (I guess) our checked in file has all the strings from those two namespaces.
Note that Glyssen also had this. See [similar PR for Glyssen](https://github.com/sillsdev/Glyssen/pull/818).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/222)
<!-- Reviewable:end -->
