### PR TITLE
Prevented multiple instances of Record In Parts dialog

### DIFF
--- a/src/HearThis/UI/RecordingToolControl.Designer.cs
+++ b/src/HearThis/UI/RecordingToolControl.Designer.cs
@@ -17,9 +17,13 @@ namespace HearThis.UI
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-			if (disposing)
-				components?.Dispose();
-            base.Dispose(disposing);
+	        if (disposing)
+	        {
+		        Application.RemoveMessageFilter(this);
+		        components?.Dispose();
+	        }
+
+	        base.Dispose(disposing);
         }
 
         

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -163,6 +163,8 @@ namespace HearThis.UI
 					SetProject(((Shell) sender).Project);
 				};
 			}
+
+			Application.AddMessageFilter(this);
 		}
 
 		private void OnSettingsProtectionChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -259,23 +261,6 @@ namespace HearThis.UI
 				bookButton.Invalidate();
 			}
 			_scriptSlider.Refresh();
-		}
-
-		/// <summary>
-		/// This invokes the message filter that allows the control to interpret various keystrokes as button presses.
-		/// It is tempting to try to manage this from within this control, e.g., in the constructor and Dispose method.
-		/// However, this fails to disable the message filter when dialogs (or the localization tool) are launched.
-		/// The interception of the space key, especially, is disconcerting while some dialogs are active.
-		/// So, instead, we arrange to call these methods from the OnActivated and OnDeactivate methods of the parent window.
-		/// </summary>
-		public void StartFilteringMessages()
-		{
-			Application.AddMessageFilter(this);
-		}
-
-		public void StopFilteringMessages()
-		{
-			Application.RemoveMessageFilter(this);
 		}
 
 		private void OnRecordingToolControl_MouseWheel(object sender, MouseEventArgs e)
@@ -544,7 +529,7 @@ namespace HearThis.UI
 			const int WM_KEYDOWN = 0x100;
 			const int WM_KEYUP = 0x101;
 
-			if (m.Msg != WM_KEYDOWN && m.Msg != WM_KEYUP)
+			if ((m.Msg != WM_KEYDOWN && m.Msg != WM_KEYUP) || !(FindForm()?.ContainsFocus ?? false))
 				return false;
 
 			if (m.Msg == WM_KEYUP && (Keys) m.WParam != Keys.Space)
@@ -554,7 +539,8 @@ namespace HearThis.UI
 			{
 				case Keys.OemPeriod:
 				case Keys.Decimal:
-					MessageBox.Show("To play the clip, press the TAB key.");
+					if (_audioButtonsControl.HaveSomethingToRecord)
+						MessageBox.Show("To play the clip, press the TAB key.");
 					break;
 
 				case Keys.Tab:
@@ -581,7 +567,7 @@ namespace HearThis.UI
 					break;
 
 				case Keys.P:
-					longLineButton_Click(this, new EventArgs());
+					longLineButton_Click(this, EventArgs.Empty);
 					break;
 
 				case Keys.Delete:

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -405,7 +405,6 @@ namespace HearThis.UI
 				Application.Idle += ShowReleaseNotesWhenActiveAndIdle;
 			}
 
-			_recordingToolControl1.StartFilteringMessages();
 			_recordingToolControl1.MicCheckingEnabled = true;
 		}
 
@@ -423,7 +422,6 @@ namespace HearThis.UI
 		protected override void OnDeactivate(EventArgs e)
 		{
 			base.OnDeactivate(e);
-			_recordingToolControl1.StopFilteringMessages();
 			_recordingToolControl1.MicCheckingEnabled = false;
 		}
 


### PR DESCRIPTION
This approach also improves encapsulation, as the Shell does not need to know about RecordInParts role as a message filter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/227)
<!-- Reviewable:end -->
