### PR TITLE
HT-429: Prevent crash in ShiftClipsDlg caused by an ill-constructed model

### DIFF
--- a/src/HearThis/Script/ShiftClipsViewModel.cs
+++ b/src/HearThis/Script/ShiftClipsViewModel.cs
@@ -47,6 +47,8 @@ namespace HearThis.Script
 			{
 				_linesToShiftForward = project.GetRecordableBlocksUpThroughNextHoleToTheRight();
 				_linesToShiftBackward = project.GetRecordableBlocksAfterPreviousHoleToTheLeft();
+				if (!_linesToShiftBackward.Any())
+					ShiftingForward = true;
 			}
 			else // Shifting extra clips backward.
 			{

--- a/src/HearThis/UI/ShiftClipsDlg.cs
+++ b/src/HearThis/UI/ShiftClipsDlg.cs
@@ -1,7 +1,7 @@
 ﻿// --------------------------------------------------------------------------------------------
-#region // Copyright (c) 2021, SIL International. All Rights Reserved.
-// <copyright from='2019' to='2021' company='SIL International'>
-//		Copyright (c) 2021, SIL International. All Rights Reserved.
+#region // Copyright (c) 2022, SIL International. All Rights Reserved.
+// <copyright from='2019' to='2022' company='SIL International'>
+//		Copyright (c) 2022, SIL International. All Rights Reserved.
 //
 //		Distributable under the terms of the MIT License (https://sil.mit-license.org/)
 // </copyright>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/228)
<!-- Reviewable:end -->
