### PR TITLE
HT-429: Prevent InvalidOperationException in CheckForProblems mode

### DIFF
--- a/src/HearThis/Script/Project.cs
+++ b/src/HearThis/Script/Project.cs
@@ -577,11 +577,14 @@ namespace HearThis.Script
 				if (!IsLineCurrentlyRecordable(bookInfo.BookNumber, chapter, i))
 					break;
 				var block = bookInfo.ScriptProvider.GetBlock(bookInfo.BookNumber, chapter, i);
+				if (block.Skipped)
+					break;
+
 				if (reverseList)
 					lines.Insert(0, block);
 				else
 					lines.Add(block);
-				if (!block.Skipped && !ClipRepository.HasClip(Name, bookInfo.Name, chapter, i, ScriptProvider))
+				if (!ClipRepository.HasClip(Name, bookInfo.Name, chapter, i, ScriptProvider))
 					return lines;
 			}
 			return new List<ScriptLine>();

--- a/src/HearThis/Script/ShiftClipsViewModel.cs
+++ b/src/HearThis/Script/ShiftClipsViewModel.cs
@@ -47,7 +47,7 @@ namespace HearThis.Script
 			{
 				_linesToShiftForward = project.GetRecordableBlocksUpThroughNextHoleToTheRight();
 				_linesToShiftBackward = project.GetRecordableBlocksAfterPreviousHoleToTheLeft();
-				if (!_linesToShiftBackward.Any())
+				if (!_linesToShiftBackward.Any() && _linesToShiftForward.Any())
 					ShiftingForward = true;
 			}
 			else // Shifting extra clips backward.


### PR DESCRIPTION
HT-430: This might not be the final solution, but for now, when looking for shiftable blocks, stop when we hit a skipped block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/231)
<!-- Reviewable:end -->
