### PR TITLE
Re-instated tool tip to help user deal with extra clips.

### DIFF
--- a/src/HearThis/Script/Project.cs
+++ b/src/HearThis/Script/Project.cs
@@ -373,6 +373,14 @@ namespace HearThis.Script
 				SelectedChapterInfo.ChapterNumber1Based, block);
 		}
 
+		public bool IsHole(int block) =>
+			block >= 0 && block < LineCountForChapter &&
+			!HasClipForUnfilteredScriptLine(block) && !GetBlock(block).Skipped;
+
+		private ScriptLine GetBlock(int block) =>
+			ScriptProvider.GetBlock(SelectedBook.BookNumber,
+				SelectedChapterInfo.ChapterNumber1Based, block);
+
 		public bool HasRecordedClipForSelectedScriptLine() =>
 			SelectedScriptBlock != LineCountForChapter && HasClipForUnfilteredScriptLine(SelectedScriptBlock);
 
@@ -647,8 +655,7 @@ namespace HearThis.Script
 		public void HandleExtraBlocksShifted()
 		{
 			var lineNumberOfLastRealBlock = SelectedChapterInfo.GetScriptBlockCount() - 1;
-			var scriptLine = ScriptProvider.GetBlock(SelectedBook.BookNumber,
-				SelectedChapterInfo.ChapterNumber1Based, lineNumberOfLastRealBlock);
+			var scriptLine = GetBlock(lineNumberOfLastRealBlock);
 			scriptLine.RecordingTime = GetActualClipRecordingTime(lineNumberOfLastRealBlock);
 			SelectedChapterInfo.OnScriptBlockRecorded(scriptLine);
 			RefreshExtraClips();

--- a/src/HearThis/UI/RecordingToolControl.Designer.cs
+++ b/src/HearThis/UI/RecordingToolControl.Designer.cs
@@ -486,6 +486,7 @@ namespace HearThis.UI
 			this._scriptSlider.Value = 4;
 			this._scriptSlider.ValueChanged += new System.EventHandler(this.OnLineSlider_ValueChanged);
 			this._scriptSlider.MouseClick += new System.Windows.Forms.MouseEventHandler(this._scriptSlider_MouseClick);
+			this._scriptSlider.MouseEnterSegment += new DiscontiguousProgressTrackBar.MouseEnterSegmentHandler(_scriptSlider_MouseEnterSegment);
 			// 
 			// _peakMeter
 			// 

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -1300,7 +1300,8 @@ namespace HearThis.UI
 		private void _scriptSlider_MouseClick(object sender, MouseEventArgs e)
 		{
 			if (Settings.Default.AllowDisplayOfShiftClipsMenu &&
-				e.Button == MouseButtons.Right && HaveRecording)
+				_project.LineCountForChapter > 1 &&
+				e.Button == MouseButtons.Right && _project.SelectedLineHasClip)
 			{
 				_contextMenuStrip.Show(_scriptSlider, e.Location);
 			}
@@ -1313,7 +1314,7 @@ namespace HearThis.UI
 			{
 				tip = LocalizationManager.GetString("RecordingControl.DeleteExtraClipTooltip",
 					"If this extra clip does not correspond to any block, delete it.");
-				if (Settings.Default.AllowDisplayOfShiftClipsMenu)
+				if (Settings.Default.AllowDisplayOfShiftClipsMenu && _project.IsHole(value - 1))
 				{
 					tip += " " + Format(LocalizationManager.GetString(
 						"RecordingControl.ShiftClipsHintTooltip",


### PR DESCRIPTION
Prevent showing shift clips menu for chapter with only one block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/232)
<!-- Reviewable:end -->
