### PR TITLE
StringDifferenceFinder improvements

### DIFF
--- a/src/HearThis/HearThis.csproj
+++ b/src/HearThis/HearThis.csproj
@@ -155,32 +155,32 @@
       <Version>9.2.6.5</Version>
     </PackageReference>
     <PackageReference Include="SIL.Core">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
     <PackageReference Include="SIL.Core.Desktop">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
     <PackageReference Include="SIL.DblBundle">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
     <PackageReference Include="SIL.libpalaso.l10ns">
       <Version>9.0.1-beta0011</Version>
       <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
     <PackageReference Include="SIL.Media">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
     <PackageReference Include="SIL.Scripture">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
     <PackageReference Include="SIL.Windows.Forms">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
     <PackageReference Include="SIL.Windows.Forms.DblBundle">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
     <PackageReference Include="SIL.WritingSystems">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
     <PackageReference Include="UnicodeInformation" Version="2.6.0" />
     <PackageReference Include="ZXing.Net">

--- a/src/HearThis/HearThis.csproj
+++ b/src/HearThis/HearThis.csproj
@@ -125,8 +125,8 @@
       <Version>1.2.4.11</Version>
     </PackageReference>
     <PackageReference Include="DotNetZip" Version="1.16.0" />
-    <PackageReference Include="icu.net" Version="2.8.0-beta.10" />
-    <PackageReference Include="Icu4c.Win.Full.Lib" Version="62.2.1-beta" />
+    <PackageReference Include="icu.net" Version="2.8.1" />
+    <PackageReference Include="Icu4c.Win.Fw.Lib" Version="70.1.152" />
     <PackageReference Include="L10NSharp">
       <Version>5.0.0</Version>
     </PackageReference>
@@ -155,32 +155,32 @@
       <Version>9.2.6.5</Version>
     </PackageReference>
     <PackageReference Include="SIL.Core">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
     <PackageReference Include="SIL.Core.Desktop">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
     <PackageReference Include="SIL.DblBundle">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
     <PackageReference Include="SIL.libpalaso.l10ns">
       <Version>9.0.1-beta0011</Version>
       <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
     <PackageReference Include="SIL.Media">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
     <PackageReference Include="SIL.Scripture">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
     <PackageReference Include="SIL.Windows.Forms">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
     <PackageReference Include="SIL.Windows.Forms.DblBundle">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
     <PackageReference Include="SIL.WritingSystems">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
     <PackageReference Include="UnicodeInformation" Version="2.6.0" />
     <PackageReference Include="ZXing.Net">

--- a/src/HearThis/HearThis.csproj
+++ b/src/HearThis/HearThis.csproj
@@ -155,32 +155,32 @@
       <Version>9.2.6.5</Version>
     </PackageReference>
     <PackageReference Include="SIL.Core">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
     <PackageReference Include="SIL.Core.Desktop">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
     <PackageReference Include="SIL.DblBundle">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
     <PackageReference Include="SIL.libpalaso.l10ns">
       <Version>9.0.1-beta0011</Version>
       <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
     <PackageReference Include="SIL.Media">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
     <PackageReference Include="SIL.Scripture">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
     <PackageReference Include="SIL.Windows.Forms">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
     <PackageReference Include="SIL.Windows.Forms.DblBundle">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
     <PackageReference Include="SIL.WritingSystems">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
     <PackageReference Include="UnicodeInformation" Version="2.6.0" />
     <PackageReference Include="ZXing.Net">

--- a/src/HearThis/Program.cs
+++ b/src/HearThis/Program.cs
@@ -205,6 +205,7 @@ namespace HearThis
 
 				if (!Sldr.IsInitialized)
 					Sldr.Initialize();
+				Icu.Wrapper.ConfineIcuVersions(70);
 				try
 				{
 					var mainWindow = new Shell(launchedFromInstaller, showReleaseNotes);

--- a/src/HearThis/Utils/StringDifferences/StringDifferenceFinder.cs
+++ b/src/HearThis/Utils/StringDifferences/StringDifferenceFinder.cs
@@ -345,8 +345,8 @@ namespace HearThis.StringDifferences
 					if (ccState.CharactersToRemove > 0)
 					{
 						bldr.Remove(0, ccState.CharactersToRemove);
-						n -= ccState.CharactersToRemove;
-						o -= ccState.CharactersToRemove;
+						n += ccState.CharactersToRemove;
+						o += ccState.CharactersToRemove;
 					}
 					break;
 				}

--- a/src/HearThis/Utils/StringDifferences/StringDifferenceFinder.cs
+++ b/src/HearThis/Utils/StringDifferences/StringDifferenceFinder.cs
@@ -147,7 +147,7 @@ namespace HearThis.StringDifferences
 				else if (IsLowSurrogate((char)chOrig))
 				{
 					surrogate = true;
-					chOrig = ConvertToUtf32(origStr, o - 1);
+					chOrig = ConvertToUtf32(origStr, --o);
 				}
 				else
 				{
@@ -158,7 +158,7 @@ namespace HearThis.StringDifferences
 				if (IsHighSurrogate((char)chNew))
 					chNew = ConvertToUtf32(newStr, n);
 				else if (IsLowSurrogate((char)chNew))
-					chNew = ConvertToUtf32(newStr, n - 1);
+					chNew = ConvertToUtf32(newStr, --n);
 
 				var b = (CharactersToKeepTogether)Math.Max((int)GetCharactersToKeepWith(chOrig),
 					(int)GetCharactersToKeepWith(chNew));
@@ -169,7 +169,7 @@ namespace HearThis.StringDifferences
 				if (_matched)
 				{
 					if (origStr.IsLikelyWordForming(o))
-						_charactersInCurrentWord++;
+						_charactersInCurrentWord += surrogate ? 2 : 1;
 					else
 						_charactersInCurrentWord = 0;
 

--- a/src/HearThisTests/HearThisTests.csproj
+++ b/src/HearThisTests/HearThisTests.csproj
@@ -96,16 +96,16 @@
       <Version>9.2.6.5</Version>
     </PackageReference>
     <PackageReference Include="SIL.Core">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
-    <PackageReference Include="SIL.Core.Desktop" Version="10.0.0-beta0075" />
-    <PackageReference Include="SIL.DblBundle.Tests" Version="10.0.0-beta0075" />
+    <PackageReference Include="SIL.Core.Desktop" Version="10.0.0-beta0079" />
+    <PackageReference Include="SIL.DblBundle.Tests" Version="10.0.0-beta0079" />
     <PackageReference Include="SIL.Scripture">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
-    <PackageReference Include="SIL.Windows.Forms.DblBundle" Version="10.0.0-beta0075" />
+    <PackageReference Include="SIL.Windows.Forms.DblBundle" Version="10.0.0-beta0079" />
     <PackageReference Include="SIL.WritingSystems">
-      <Version>10.0.0-beta0075</Version>
+      <Version>10.0.0-beta0079</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/HearThisTests/HearThisTests.csproj
+++ b/src/HearThisTests/HearThisTests.csproj
@@ -96,16 +96,16 @@
       <Version>9.2.6.5</Version>
     </PackageReference>
     <PackageReference Include="SIL.Core">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
-    <PackageReference Include="SIL.Core.Desktop" Version="10.0.0-beta0072" />
-    <PackageReference Include="SIL.DblBundle.Tests" Version="10.0.0-beta0072" />
+    <PackageReference Include="SIL.Core.Desktop" Version="10.0.0-beta0075" />
+    <PackageReference Include="SIL.DblBundle.Tests" Version="10.0.0-beta0075" />
     <PackageReference Include="SIL.Scripture">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
-    <PackageReference Include="SIL.Windows.Forms.DblBundle" Version="10.0.0-beta0072" />
+    <PackageReference Include="SIL.Windows.Forms.DblBundle" Version="10.0.0-beta0075" />
     <PackageReference Include="SIL.WritingSystems">
-      <Version>10.0.0-beta0072</Version>
+      <Version>10.0.0-beta0075</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/HearThisTests/HearThisTests.csproj
+++ b/src/HearThisTests/HearThisTests.csproj
@@ -81,10 +81,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DotNetZip" Version="1.16.0" />
-    <PackageReference Include="icu.net" Version="2.8.0-beta.10" />
-    <PackageReference Include="Icu4c.Win.Full.Lib">
-      <Version>62.2.1-beta</Version>
-    </PackageReference>
+    <PackageReference Include="icu.net" Version="2.8.1" />
+    <PackageReference Include="Icu4c.Win.Fw.Lib" Version="70.1.152" />
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
     </PackageReference>
@@ -98,16 +96,16 @@
       <Version>9.2.6.5</Version>
     </PackageReference>
     <PackageReference Include="SIL.Core">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
-    <PackageReference Include="SIL.Core.Desktop" Version="10.0.0-beta0058" />
-    <PackageReference Include="SIL.DblBundle.Tests" Version="10.0.0-beta0058" />
+    <PackageReference Include="SIL.Core.Desktop" Version="10.0.0-beta0072" />
+    <PackageReference Include="SIL.DblBundle.Tests" Version="10.0.0-beta0072" />
     <PackageReference Include="SIL.Scripture">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
-    <PackageReference Include="SIL.Windows.Forms.DblBundle" Version="10.0.0-beta0058" />
+    <PackageReference Include="SIL.Windows.Forms.DblBundle" Version="10.0.0-beta0072" />
     <PackageReference Include="SIL.WritingSystems">
-      <Version>10.0.0-beta0058</Version>
+      <Version>10.0.0-beta0072</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/HearThisTests/Utils/StringDifferences/StringDifferenceFinderTests.cs
+++ b/src/HearThisTests/Utils/StringDifferences/StringDifferenceFinderTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using HearThis.StringDifferences;
+﻿using HearThis.StringDifferences;
 using NUnit.Framework;
 using System.Linq;
 using System.Text;
@@ -10,18 +9,15 @@ namespace HearThisTests.Utils.StringDifferences
 	[TestFixture]
 	class StringDifferenceFinderTests
 	{
-		private bool _unicode13OrLater;
-
 		[OneTimeSetUp]
 		public void SetUpFixture()
 		{
 			Sldr.Initialize();
+			Icu.Wrapper.ConfineIcuVersions(70);
 			Icu.Wrapper.Init();
-			_unicode13OrLater = double.Parse(Icu.Wrapper.UnicodeVersion) >= 13.0;
-			if (_unicode13OrLater)
-				Assert.That(Icu.Character.GetCharType(0x16FF0), Is.EqualTo(Icu.Character.UCharCategory.COMBINING_SPACING_MARK));
-			else
-				Trace.WriteLine("Test cases requiring Unicode 13.0 will be ignored.");
+			// Sanity check to make sure we have a version of ICU that will work
+			Assert.That(double.Parse(Icu.Wrapper.UnicodeVersion), Is.GreaterThanOrEqualTo(13.0));
+			Assert.That(Icu.Character.GetCharType(0x16FF0), Is.EqualTo(Icu.Character.UCharCategory.COMBINING_SPACING_MARK));
 		}
 
 		[TestCase("This is the same string.")]
@@ -344,8 +340,6 @@ namespace HearThisTests.Utils.StringDifferences
 			string o, string n, string del1, string add1, string del2, string add2,
 			NormalizationForm normalization = NormalizationForm.FormD)
 		{
-			if (!_unicode13OrLater && ((o+n).Contains("\U00016FF0") || (o+n).Contains("\U00016FF1")))
-				throw new IgnoreException("Test case requires a newer version of ICU.");
 			var d = new StringDifferenceFinder(o.Normalize(normalization), n.Normalize(normalization));
 			Assert.That(d.OriginalStringDifferences.Count, Is.EqualTo(5));
 			Assert.That(d.NewStringDifferences.Count, Is.EqualTo(5));

--- a/src/HearThisTests/Utils/StringDifferences/StringDifferenceFinderTests.cs
+++ b/src/HearThisTests/Utils/StringDifferences/StringDifferenceFinderTests.cs
@@ -1,4 +1,6 @@
-﻿using HearThis.StringDifferences;
+﻿using System.Diagnostics;
+using System;
+using HearThis.StringDifferences;
 using NUnit.Framework;
 using System.Linq;
 using System.Text;
@@ -229,6 +231,36 @@ namespace HearThisTests.Utils.StringDifferences
 			Assert.That(origSamePart.Text, Is.EqualTo(newSamePart.Text));
 			
 			Assert.That(origDeletion.Text + origSamePart.Text , Is.EqualTo(o));
+		}
+
+		// HT-444
+		[TestCase("This is evenmore embarrassing.", "This is even more embarrassing.")]
+		public void ComputeDifferences_SpaceAddedBetweenWords_AdditionShowsSurroundingWords(
+			string o, string n)
+		{
+			var d = new StringDifferenceFinder(o, n);
+			Assert.That(d.OriginalStringDifferences.Count, Is.EqualTo(3));
+			Assert.That(d.OriginalStringDifferences[0].Type, Is.EqualTo(DifferenceType.Same));
+			Assert.That(d.NewStringDifferences[0].Type, Is.EqualTo(DifferenceType.Same));
+			Assert.That(d.OriginalStringDifferences[1].Type, Is.EqualTo(DifferenceType.Deletion));
+			Assert.That(d.NewStringDifferences[1].Type, Is.EqualTo(DifferenceType.Addition));
+			Assert.That(d.OriginalStringDifferences[2].Type, Is.EqualTo(DifferenceType.Same));
+			Assert.That(d.NewStringDifferences[2].Type, Is.EqualTo(DifferenceType.Same));
+
+			var origDeletion = d.OriginalStringDifferences[1];
+			var newAddition = d.NewStringDifferences[1];
+			var delText = origDeletion.Text;
+			var addText = newAddition.Text;
+			Assert.That(o, Does.Contain(delText));
+			Assert.That(n, Does.Contain(addText));
+			Assert.That(delText, Does.Not.Contain(" "));
+			var indexOfSpace = newAddition.Text.IndexOf(" ", StringComparison.Ordinal);
+			Assert.That(indexOfSpace, Is.GreaterThan(0));
+			Assert.That(newAddition.Text.Length, Is.EqualTo(origDeletion.Text.Length + 1));
+			Assert.That(delText, Is.EqualTo(addText.Substring(0, indexOfSpace) +
+				addText.Substring(indexOfSpace + 1)));
+
+			Assert.That(d.OriginalStringDifferences[0].Text + delText + d.OriginalStringDifferences[2].Text, Is.EqualTo(o));
 		}
 
 		[TestCase("No puede el mundo aborreceros a vosotros; mas a mí me aborrece, porque yo testifico de él, que sus obras son malas.",

--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -239,16 +239,16 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 			<File Id="icu.net.dll" Name="icu.net.dll" KeyPath="yes" Source="..\..\output\$(var.config)\icu.net.dll" />
 		  </Component>
 
-		  <Component Id="icudt62.dll" Guid="*">
-			<File Id="icudt62.dll" Name="icudt62.dll" KeyPath="yes" Source="..\..\output\$(var.config)\lib\win-x64\icudt62.dll" />
+		  <Component Id="icudt70.dll" Guid="*">
+			<File Id="icudt70.dll" Name="icudt70.dll" KeyPath="yes" Source="..\..\output\$(var.config)\lib\win-x64\icudt70.dll" />
 		  </Component>
 
-		  <Component Id="icuin62.dll" Guid="*">
-			<File Id="icuin62.dll" Name="icuin62.dll" KeyPath="yes" Source="..\..\output\$(var.config)\lib\win-x64\icuin62.dll" />
+		  <Component Id="icuin70.dll" Guid="*">
+			<File Id="icuin70.dll" Name="icuin70.dll" KeyPath="yes" Source="..\..\output\$(var.config)\lib\win-x64\icuin70.dll" />
 		  </Component>
 
-		  <Component Id="icuuc62.dll" Guid="*">
-			<File Id="icuuc62.dll" Name="icuuc62.dll" KeyPath="yes" Source="..\..\output\$(var.config)\lib\win-x64\icuuc62.dll" />
+		  <Component Id="icuuc70.dll" Guid="*">
+			<File Id="icuuc70.dll" Name="icuuc70.dll" KeyPath="yes" Source="..\..\output\$(var.config)\lib\win-x64\icuuc70.dll" />
 		  </Component>
 		  <Component Id="System.Memory.dll" Guid="{333F04FF-A3A1-4743-9BE3-08142F0BE21A}">
 			<File Id="System.Memory.dll" Name="System.Memory.dll" KeyPath="yes" Source="..\..\output\$(var.config)\System.Memory.dll" />
@@ -310,9 +310,9 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 	  <ComponentRef Id="Newtonsoft.Json.dll"/>
 	  <ComponentRef Id="CreateProgramDataFolder"/>
 	  <ComponentRef Id="icu.net.dll"/>
-	  <ComponentRef Id="icudt62.dll"/>
-	  <ComponentRef Id="icuin62.dll"/>
-	  <ComponentRef Id="icuuc62.dll"/>
+	  <ComponentRef Id="icudt70.dll"/>
+	  <ComponentRef Id="icuin70.dll"/>
+	  <ComponentRef Id="icuuc70.dll"/>
 	  <ComponentRef Id="System.Memory.dll"/>
 	  <ComponentRef Id="System.Runtime.CompilerServices.Unsafe.dll"/>
 	  <ComponentGroupRef Id ="DistFiles"/>


### PR DESCRIPTION
Upgrade to latest ICU (v. 13 of Unicode) and libpalaso libraries to get improved behavior in StringDifferenceFinder
Fixed bugs in StringDifferenceFinder related to handling of surrogate pairs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/242)
<!-- Reviewable:end -->
