### PR TITLE
HT-259: Set UseZip64WhenSaving to allow HearThis packs that exceed 32-bit limits

### DIFF
--- a/src/HearThis/Script/HearThisPackMaker.cs
+++ b/src/HearThis/Script/HearThisPackMaker.cs
@@ -28,6 +28,8 @@ namespace HearThis.Script
 			_progress = progress;
 			using (var zip = new ZipFile(Encoding.UTF8))
 			{
+				// HT-259: Uncompressed size, or offset exceeds the maximum value.
+				zip.UseZip64WhenSaving = Zip64Option.AsNecessary;
 				ZipUpWavAndInfoFiles(zip, _rootFolder);
 				// And we want this one more file besides the .wav and the info.xml files, so we can transfer
 				// information about which lines are skipped.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/245)
<!-- Reviewable:end -->
