### PR TITLE
Changed order of SLDR and ICU initialization

### DIFF
--- a/src/HearThisTests/Utils/StringDifferences/StringDifferenceFinderTests.cs
+++ b/src/HearThisTests/Utils/StringDifferences/StringDifferenceFinderTests.cs
@@ -13,9 +13,12 @@ namespace HearThisTests.Utils.StringDifferences
 		[OneTimeSetUp]
 		public void SetUpFixture()
 		{
-			Sldr.Initialize();
+			// Used to initialize SLDR first, then ICU, but that seems to be the cause of test
+			// failures n this fixture on ONE of the available TeamCity agents. Not sure why.
+			// JasonN tipped me off to this possible cause because FLEx was having similar issues.
 			Icu.Wrapper.ConfineIcuVersions(70);
 			Icu.Wrapper.Init();
+			Sldr.Initialize();
 			// Sanity check to make sure we have a version of ICU that will work
 			Assert.That(double.Parse(Icu.Wrapper.UnicodeVersion), Is.GreaterThanOrEqualTo(13.0));
 			Assert.That(Icu.Character.GetCharType(0x16FF0), Is.EqualTo(Icu.Character.UCharCategory.COMBINING_SPACING_MARK));


### PR DESCRIPTION
 Trying to see if that fixes test failures on TC agent ba-win7-64-s1-401.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/246)
<!-- Reviewable:end -->
