### PR TITLE
Fixed the display/behavior of Check for Problems view in two cases

### DIFF
--- a/src/HearThis/UI/ScriptTextHasChangedControl.cs
+++ b/src/HearThis/UI/ScriptTextHasChangedControl.cs
@@ -276,6 +276,8 @@ namespace HearThis.UI
 				SetProblemSummaryTextToScriptTextAtTimeOfRecordingUnknown(_lblProblemSummary);
 				_actionsToSetLocalizedTextForCtrls[_lblProblemSummary] = SetProblemSummaryTextToScriptTextAtTimeOfRecordingUnknown;
 
+				_txtThen.Visible = false;
+
 				if (haveRecording)
 				{
 					// We have a clip, but we don't know anything about the script at the time it was recorded.
@@ -308,7 +310,10 @@ namespace HearThis.UI
 
 					if (haveBackup)
 						ShowResolution(_btnDelete, () => ReadyToReRecordText);
-					else if (currentRecordingInfo.OriginalText != null && _txtNow.Text != currentRecordingInfo.OriginalText)
+					else if (currentRecordingInfo.OriginalText != null && _txtNow.Text != currentRecordingInfo.OriginalText &&
+					         // Have to check this because the text might have changed AGAIN since the last time the user said
+							 // it was okay:
+					         _txtNow.Text == currentRecordingInfo.Text)
 						ShowResolution(_btnUseExisting);
 				}
 				else


### PR DESCRIPTION
1) Going from a block that shows a difference between then and now to a block with no recording info (recorded with an older version of HearThis).
2) Selecting a block that was previously marked as being OK following a minor text change, but then the text is changed again, such that the recording needs to be re-evaluated.
Note: I found these two problems while looking at HT-461, but I'm not very sure that either of these is actually related to the originally reported bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/267)
<!-- Reviewable:end -->
