### PR TITLE
HT-465: Handle edge cases with skip/clip files and prevent crash when both unexpectedly exist

### DIFF
--- a/src/HearThis/Publishing/ClipRepository.cs
+++ b/src/HearThis/Publishing/ClipRepository.cs
@@ -564,7 +564,7 @@ namespace HearThis.Publishing
 					// information that might enable me to fix it.
 					var skipWriteTime = new FileInfo(skipPath).LastWriteTimeUtc;
 					var clipWriteTime = new FileInfo(recordingPath).LastWriteTimeUtc;
-					var details = new Dictionary<string, string>(1)
+					var details = new Dictionary<string, string>
 					{
 						["recordingPath"] = recordingPath,
 						["skipWriteTime"] = skipWriteTime.ToISO8601TimeFormatWithUTCString(),
@@ -590,7 +590,7 @@ namespace HearThis.Publishing
 
 					var msg = Format(LocalizationManager.GetString("ClipRepository.BothSkipAndClipExist",
 						"{0} found an existing clip for a block that was marked as being skipped.",
-							"Param 0: \"HearThis\" (product name)"), Program.kProduct);
+							"Low-priority for localization. Param 0: \"HearThis\" (product name)"), Program.kProduct);
 
 					if (skipWriteTime.CompareTo(clipWriteTime) > 0)
 					{
@@ -602,7 +602,7 @@ namespace HearThis.Publishing
 							Format(LocalizationManager.GetString("ClipRepository.SkipFileIsNewer",
 							"Because the skip file is newer, that file is replacing the existing" +
 							" clip, but the other version is being kept as {0}",
-							"Param 0: file name"), backedUpClipFile));
+							"Low-priority for localization. Param 0: file name"), backedUpClipFile));
 					}
 					else
 					{
@@ -615,7 +615,7 @@ namespace HearThis.Publishing
 							Format(LocalizationManager.GetString("ClipRepository.SkipFileIsNewer",
 								"Because the existing clip is newer, that file is being kept, " +
 								"but the other version is being kept as {0}",
-								"Param 0: file name"), backedUpSkipFile));
+								"Low-priority for localization. Param 0: file name"), backedUpSkipFile));
 						return false;
 					}
 				}

--- a/src/HearThis/Script/ScriptProviderBase.cs
+++ b/src/HearThis/Script/ScriptProviderBase.cs
@@ -601,7 +601,7 @@ namespace HearThis.Script
 		{
 			ProcessBlocksHavingStyle(style, (projectName, bookName, chapterIndex, blockIndex, scriptProvider) =>
 				ClipRepository.RestoreBackedUpClip(projectName, bookName, chapterIndex, blockIndex, scriptProvider),
-				true);
+				skipExplicitlySkippedBlocks: true);
 		}
 
 		private void ProcessBlocksHavingStyle(string style,

--- a/src/HearThisTests/ClipRepositoryTests.cs
+++ b/src/HearThisTests/ClipRepositoryTests.cs
@@ -14,7 +14,7 @@ using DateTime = System.DateTime;
 namespace HearThisTests
 {
 	[TestFixture]
-	public class ClipRepositoryTests
+	public partial class ClipRepositoryTests
 	{
 		private const double kMonoSampleDuration = 0.062;
 		private TestErrorReporter _errorReporter;
@@ -109,62 +109,6 @@ namespace HearThisTests
 			public bool BreakQuotesIntoBlocks => false;
 			public string BlockBreakCharacters => ". ?";
 			public bool HasProblemNeedingAttention(string bookName = null) => false;
-		}
-
-		private class ReportedErrorInfo
-		{
-			public Exception Exception;
-			public string Message;
-		}
-
-		private class TestErrorReporter : IErrorReporter
-		{
-			private readonly List<ReportedErrorInfo> _reportedProblems = new List<ReportedErrorInfo>();
-
-			public IReadOnlyList<ReportedErrorInfo> ReportedProblems => _reportedProblems;
-
-			public void ReportFatalException(Exception e)
-			{
-				throw e;
-			}
-
-			public void NotifyUserOfProblem(IRepeatNoticePolicy policy, Exception exception, string message)
-			{
-				_reportedProblems.Add(new ReportedErrorInfo {Exception = exception, Message = message });
-			}
-
-			public ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy, string alternateButton1Label, ErrorResult resultIfAlternateButtonPressed, string message)
-			{
-				if (policy == null || policy.ShouldShowMessage(message))
-					_reportedProblems.Add(new ReportedErrorInfo { Message = message });
-
-				return resultIfAlternateButtonPressed;
-			}
-
-			public void ReportNonFatalException(Exception exception, IRepeatNoticePolicy policy)
-			{
-				if (policy == null || policy.ShouldShowErrorReportDialog(exception))
-					_reportedProblems.Add(new ReportedErrorInfo { Exception = exception });
-			}
-
-			public void ReportNonFatalExceptionWithMessage(Exception error, string message, params object[] args)
-			{
-				if (args != null && args.Any())
-					message = string.Format(message, args);
-				_reportedProblems.Add(new ReportedErrorInfo { Exception = error, Message = message });
-			}
-
-			public void ReportNonFatalMessageWithStackTrace(string message, params object[] args)
-			{
-				if (args != null && args.Any())
-					message = string.Format(message, args);
-				_reportedProblems.Add(new ReportedErrorInfo { Message = message });
-			}
-
-			public void ReportFatalMessageWithStackTrace(string message, object[] args)
-			{
-				throw new Exception(message);
-			}
 		}
 
 		[SetUp]
@@ -2095,7 +2039,7 @@ namespace HearThisTests
 			}
 		}
 
-		// The remainder of these tests are to deal with the unexpected scenarios where both clip and skip files exist.
+		#region Tests to deal with the unexpected scenarios where both clip and skip files exist.
 		// Not sure how this can happen, but see HT-465 for background. 
 
 		[Test]
@@ -2192,6 +2136,7 @@ namespace HearThisTests
 				RobustIO.DeleteDirectoryAndContents(ClipRepository.GetProjectFolder(projectName));
 			}
 		}
+		#endregion
 		#endregion
 
 		private static void CleanUpTestFolder(string chapterFolder, string testProject)

--- a/src/HearThisTests/ClipRepositoryTests.cs
+++ b/src/HearThisTests/ClipRepositoryTests.cs
@@ -8,6 +8,7 @@ using HearThis.Publishing;
 using HearThis.Script;
 using NUnit.Framework;
 using SIL.IO;
+using SIL.Reporting;
 using DateTime = System.DateTime;
 
 namespace HearThisTests
@@ -16,6 +17,7 @@ namespace HearThisTests
 	public class ClipRepositoryTests
 	{
 		private const double kMonoSampleDuration = 0.062;
+		private TestErrorReporter _errorReporter;
 
 		private class TestPublishingModel : PublishingModel
 		{
@@ -107,6 +109,69 @@ namespace HearThisTests
 			public bool BreakQuotesIntoBlocks => false;
 			public string BlockBreakCharacters => ". ?";
 			public bool HasProblemNeedingAttention(string bookName = null) => false;
+		}
+
+		private class ReportedErrorInfo
+		{
+			public Exception Exception;
+			public string Message;
+		}
+
+		private class TestErrorReporter : IErrorReporter
+		{
+			private readonly List<ReportedErrorInfo> _reportedProblems = new List<ReportedErrorInfo>();
+
+			public IReadOnlyList<ReportedErrorInfo> ReportedProblems => _reportedProblems;
+
+			public void ReportFatalException(Exception e)
+			{
+				throw e;
+			}
+
+			public void NotifyUserOfProblem(IRepeatNoticePolicy policy, Exception exception, string message)
+			{
+				_reportedProblems.Add(new ReportedErrorInfo {Exception = exception, Message = message });
+			}
+
+			public ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy, string alternateButton1Label, ErrorResult resultIfAlternateButtonPressed, string message)
+			{
+				if (policy == null || policy.ShouldShowMessage(message))
+					_reportedProblems.Add(new ReportedErrorInfo { Message = message });
+
+				return resultIfAlternateButtonPressed;
+			}
+
+			public void ReportNonFatalException(Exception exception, IRepeatNoticePolicy policy)
+			{
+				if (policy == null || policy.ShouldShowErrorReportDialog(exception))
+					_reportedProblems.Add(new ReportedErrorInfo { Exception = exception });
+			}
+
+			public void ReportNonFatalExceptionWithMessage(Exception error, string message, params object[] args)
+			{
+				if (args != null && args.Any())
+					message = string.Format(message, args);
+				_reportedProblems.Add(new ReportedErrorInfo { Exception = error, Message = message });
+			}
+
+			public void ReportNonFatalMessageWithStackTrace(string message, params object[] args)
+			{
+				if (args != null && args.Any())
+					message = string.Format(message, args);
+				_reportedProblems.Add(new ReportedErrorInfo { Message = message });
+			}
+
+			public void ReportFatalMessageWithStackTrace(string message, object[] args)
+			{
+				throw new Exception(message);
+			}
+		}
+
+		[SetUp]
+		public void SetUpFixture()
+		{
+			_errorReporter = new TestErrorReporter();
+			ErrorReport.SetErrorReporter(_errorReporter);
 		}
 
 		/// <summary>
@@ -910,7 +975,7 @@ namespace HearThisTests
 			publishingInfoProvider.Verses.Add("v2-4"); // 2
 			publishingInfoProvider.Verses.Add("v2-4"); // 3
 			publishingInfoProvider.Verses.Add("v2-4"); // 4
-			publishingInfoProvider.Verses.Add("v2-4~5~6"); // 5 Unlikely scenario: Sentence starts in bridge but caontinues into following verses
+			publishingInfoProvider.Verses.Add("v2-4~5~6"); // 5 Unlikely scenario: Sentence starts in bridge but continues into following verses
 			publishingInfoProvider.VerseOffsets["2-4~5~6"] = new List<int>(new[] {10, 20}); // Verse 5 starts 25% of the way through the text
 			publishingInfoProvider.Text["2-4~5~6"] = "123456789 123456789 123456789 123456789."; // and verse 6 starts 50% of the way through the text
 			publishingInfoProvider.Verses.Add("v6~7"); // 6
@@ -1954,6 +2019,180 @@ namespace HearThisTests
 			}
 		}
 		#endregion // HT-384
+
+		#region RestoreBackedUpClip
+		[Test]
+		public void RestoreBackedUpClip_OnlySkipFileExists_ReturnsTrue()
+		{
+			const string projectName = "Dummy";
+			const string book = "Acts";
+			const int chapter = 3;
+			const int line = 4;
+			var pathToActs3_4Clip = ClipRepository.GetPathToLineRecording(projectName, book, chapter, line);
+			var pathToActs3_4Skip = Path.ChangeExtension(pathToActs3_4Clip, ClipRepository.kSkipFileExtension);
+			try
+			{
+				using (var clipContents = TempFile.FromResource(Resource1._1Channel, ".wav"))
+				{
+					RobustFile.Copy(clipContents.Path, pathToActs3_4Skip, true);
+					Assert.IsTrue(ClipRepository.RestoreBackedUpClip(projectName, book, chapter, line));
+					Assert.That(File.Exists(pathToActs3_4Clip));
+					Assert.That(!File.Exists(pathToActs3_4Skip));
+					Assert.That(_errorReporter.ReportedProblems, Is.Empty);
+				}
+			}
+			finally
+			{
+				RobustIO.DeleteDirectoryAndContents(ClipRepository.GetProjectFolder(projectName));
+			}
+		}
+
+		[Test]
+		public void RestoreBackedUpClip_OnlyClipFileExists_ReturnsFalse()
+		{
+			const string projectName = "Dummy";
+			const string book = "Acts";
+			const int chapter = 3;
+			const int line = 4;
+			var pathToActs3_4Clip = ClipRepository.GetPathToLineRecording(projectName, book, chapter, line);
+			var pathToActs3_4Skip = Path.ChangeExtension(pathToActs3_4Clip, ClipRepository.kSkipFileExtension);
+			try
+			{
+				using (var clipContents = TempFile.FromResource(Resource1._1Channel, ".wav"))
+				{
+					RobustFile.Copy(clipContents.Path, pathToActs3_4Clip, true);
+					Assert.IsFalse(ClipRepository.RestoreBackedUpClip(projectName, book, chapter, line));
+					Assert.That(File.Exists(pathToActs3_4Clip));
+					Assert.That(!File.Exists(pathToActs3_4Skip));
+					Assert.That(_errorReporter.ReportedProblems, Is.Empty);
+				}
+			}
+			finally
+			{
+				RobustIO.DeleteDirectoryAndContents(ClipRepository.GetProjectFolder(projectName));
+			}
+		}
+
+		[Test]
+		public void RestoreBackedUpClip_NeitherFileExists_ReturnsFalse()
+		{
+			const string projectName = "Dummy";
+			const string book = "Acts";
+			const int chapter = 3;
+			const int line = 4;
+			var pathToActs3_4Clip = ClipRepository.GetPathToLineRecording(projectName, book, chapter, line);
+			var pathToActs3_4Skip = Path.ChangeExtension(pathToActs3_4Clip, ClipRepository.kSkipFileExtension);
+			try
+			{
+				Assert.IsFalse(ClipRepository.RestoreBackedUpClip(projectName, book, chapter, line));
+				Assert.That(!File.Exists(pathToActs3_4Clip));
+				Assert.That(!File.Exists(pathToActs3_4Skip));
+				Assert.That(_errorReporter.ReportedProblems, Is.Empty);
+			}
+			finally
+			{
+				RobustIO.DeleteDirectoryAndContents(ClipRepository.GetProjectFolder(projectName));
+			}
+		}
+
+		// The remainder of these tests are to deal with the unexpected scenarios where both clip and skip files exist.
+		// Not sure how this can happen, but see HT-465 for background. 
+
+		[Test]
+		public void RestoreBackedUpClip_IdenticalClipAndSkipExist_ReturnsFalseAndRetainsOnlyClip()
+		{
+			const string projectName = "Dummy";
+			const string book = "Acts";
+			const int chapter = 3;
+			const int line = 4;
+			var pathToActs3_4Clip = ClipRepository.GetPathToLineRecording(projectName, book, chapter, line);
+			var pathToActs3_4Skip = Path.ChangeExtension(pathToActs3_4Clip, ClipRepository.kSkipFileExtension);
+			try
+			{
+				using (var clipContents = TempFile.FromResource(Resource1._1Channel, ".wav"))
+				{
+					RobustFile.Copy(clipContents.Path, pathToActs3_4Clip, true);
+					RobustFile.Copy(clipContents.Path, pathToActs3_4Skip, true);
+					Assert.IsFalse(ClipRepository.RestoreBackedUpClip(projectName, book, chapter, line));
+					Assert.That(File.Exists(pathToActs3_4Clip));
+					Assert.That(!File.Exists(pathToActs3_4Skip));
+					Assert.That(_errorReporter.ReportedProblems, Is.Empty);
+				}
+			}
+			finally
+			{
+				RobustIO.DeleteDirectoryAndContents(ClipRepository.GetProjectFolder(projectName));
+			}
+		}
+
+		[Test]
+		public void RestoreBackedUpClip_ExistingClipNewerThanSkipFile_ReturnsFalseAndReportsNonFatalProblem()
+		{
+			const string projectName = "Dummy";
+			const string book = "Acts";
+			const int chapter = 3;
+			const int line = 4;
+			var pathToActs3_4Clip = ClipRepository.GetPathToLineRecording(projectName, book, chapter, line);
+			var pathToActs3_4Skip = Path.ChangeExtension(pathToActs3_4Clip, ClipRepository.kSkipFileExtension);
+			var backedUpSkipFile = pathToActs3_4Skip + "old.wav";
+			try
+			{
+				using (var skipContents = TempFile.FromResource(Resource1._1Channel, ".wav"))
+				using (var clipContents = TempFile.FromResource(Resource1._2Channel, ".wav"))
+				{
+					RobustFile.Copy(skipContents.Path, pathToActs3_4Skip, true);
+					RobustFile.Copy(clipContents.Path, pathToActs3_4Clip, true);
+					Assert.IsFalse(ClipRepository.RestoreBackedUpClip(projectName, book, chapter, line));
+					Assert.That(File.Exists(pathToActs3_4Clip));
+					Assert.That(!File.Exists(pathToActs3_4Skip));
+					var reportedProblem = _errorReporter.ReportedProblems.Single();
+					Assert.That(reportedProblem.Exception, Is.Null);
+					Assert.That(reportedProblem.Message, Is.EqualTo(
+						"HearThis found an existing clip for a block that was marked as being " +
+						"skipped. Because the existing clip is newer, that file is being kept, " +
+						$"but the other version is being kept as {backedUpSkipFile}"));
+				}
+			}
+			finally
+			{
+				RobustIO.DeleteDirectoryAndContents(ClipRepository.GetProjectFolder(projectName));
+			}
+		}
+
+		[Test]
+		public void RestoreBackedUpClip_SkipFileNewerThanExistingClip_ReturnsTrueAndReportsNonFatalProblem()
+		{
+			const string projectName = "Dummy";
+			const string book = "Acts";
+			const int chapter = 3;
+			const int line = 4;
+			var pathToActs3_4Clip = ClipRepository.GetPathToLineRecording(projectName, book, chapter, line);
+			var pathToActs3_4Skip = Path.ChangeExtension(pathToActs3_4Clip, ClipRepository.kSkipFileExtension);
+			var backedUpClipFile = Path.ChangeExtension(pathToActs3_4Clip, "oldclip.wav");
+			try
+			{
+				using (var skipContents = TempFile.FromResource(Resource1._1Channel, ".wav"))
+				using (var clipContents = TempFile.FromResource(Resource1._2Channel, ".wav"))
+				{
+					RobustFile.Copy(clipContents.Path, pathToActs3_4Clip, true);
+					RobustFile.Copy(skipContents.Path, pathToActs3_4Skip, true);
+					Assert.IsTrue(ClipRepository.RestoreBackedUpClip(projectName, book, chapter, line));
+					Assert.That(File.Exists(pathToActs3_4Clip));
+					Assert.That(!File.Exists(pathToActs3_4Skip));
+					var reportedProblem = _errorReporter.ReportedProblems.Single();
+					Assert.That(reportedProblem.Exception, Is.Null);
+					Assert.That(reportedProblem.Message, Is.EqualTo(
+						"HearThis found an existing clip for a block that was marked as being " +
+						"skipped. Because the skip file is newer, that file is replacing the " +
+						$"existing clip, but the other version is being kept as {backedUpClipFile}"));
+				}
+			}
+			finally
+			{
+				RobustIO.DeleteDirectoryAndContents(ClipRepository.GetProjectFolder(projectName));
+			}
+		}
+		#endregion
 
 		private static void CleanUpTestFolder(string chapterFolder, string testProject)
 		{

--- a/src/HearThisTests/TestErrorReporter.cs
+++ b/src/HearThisTests/TestErrorReporter.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SIL.Reporting;
+
+namespace HearThisTests
+{
+	public partial class ClipRepositoryTests
+	{
+		internal class TestErrorReporter : IErrorReporter
+		{
+			internal class ReportedErrorInfo
+			{
+				public Exception Exception;
+				public string Message;
+			}
+
+			private readonly List<ReportedErrorInfo> _reportedProblems = new List<ReportedErrorInfo>();
+
+			internal IReadOnlyList<ReportedErrorInfo> ReportedProblems => _reportedProblems;
+
+			public void ReportFatalException(Exception e)
+			{
+				throw e;
+			}
+
+			public void NotifyUserOfProblem(IRepeatNoticePolicy policy, Exception exception, string message)
+			{
+				_reportedProblems.Add(new ReportedErrorInfo {Exception = exception, Message = message });
+			}
+
+			public ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy, string alternateButton1Label, ErrorResult resultIfAlternateButtonPressed, string message)
+			{
+				if (policy == null || policy.ShouldShowMessage(message))
+					_reportedProblems.Add(new ReportedErrorInfo { Message = message });
+
+				return resultIfAlternateButtonPressed;
+			}
+
+			public void ReportNonFatalException(Exception exception, IRepeatNoticePolicy policy)
+			{
+				if (policy == null || policy.ShouldShowErrorReportDialog(exception))
+					_reportedProblems.Add(new ReportedErrorInfo { Exception = exception });
+			}
+
+			public void ReportNonFatalExceptionWithMessage(Exception error, string message, params object[] args)
+			{
+				if (args != null && args.Any())
+					message = string.Format(message, args);
+				_reportedProblems.Add(new ReportedErrorInfo { Exception = error, Message = message });
+			}
+
+			public void ReportNonFatalMessageWithStackTrace(string message, params object[] args)
+			{
+				if (args != null && args.Any())
+					message = string.Format(message, args);
+				_reportedProblems.Add(new ReportedErrorInfo { Message = message });
+			}
+
+			public void ReportFatalMessageWithStackTrace(string message, object[] args)
+			{
+				throw new Exception(message);
+			}
+		}
+	}
+}


### PR DESCRIPTION
1. Deal with possibility of both a skip and clip file existing for a particular block.
2. Avoid renaming skip files back to wav files (clips) for blocks that were explicitly skipped, then had their style skipped, and then have their style unskipped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/274)
<!-- Reviewable:end -->
