### PR TITLE
HT-193: Prevent reporting partially complete chapters when blocks are merely skipped

### DIFF
--- a/src/HearThis/Script/ChapterInfo.cs
+++ b/src/HearThis/Script/ChapterInfo.cs
@@ -206,7 +206,9 @@ namespace HearThis.Script
 		}
 
 		/// <summary>
-		/// "Recorded" actually means either recorded or skipped.
+		/// "Recorded" actually means either recorded or skipped (unless nothing has been recorded
+		/// or everything is skipped - we don't want to report partially recorded just because a
+		/// block or two is skipped).
 		/// It is filtered by current character.
 		/// </summary>
 		/// <returns>A percentage between 0 and 100%</returns>
@@ -234,8 +236,11 @@ namespace HearThis.Script
 			//if (Recordings.Count + skippedScriptLines == scriptLineCount)
 			//    return 100;
 
-			return (int)(100 * (ClipRepository.GetCountOfRecordingsInFolder(Path.GetDirectoryName(_filePath), _scriptProvider) + skippedScriptLines)/
-				(float)(scriptLineCount));
+			var cRecordings = ClipRepository.GetCountOfRecordingsInFolder(Path.GetDirectoryName(_filePath), _scriptProvider);
+			if (cRecordings == 0 && skippedScriptLines < scriptLineCount)
+				skippedScriptLines = 0;
+
+			return (int)(100 * (cRecordings + skippedScriptLines) / (float)scriptLineCount);
 		}
 
 		public bool RecordingsFinished

--- a/src/HearThisTests/ChapterInfoTests.cs
+++ b/src/HearThisTests/ChapterInfoTests.cs
@@ -523,7 +523,7 @@ namespace HearThisTests
 		}
 
 		[Test]
-		public void CalculatePercentageRecorded_ThreeRecordingsOneSkippedLines_ThirtySixPercent()
+		public void CalculatePercentageRecorded_ThreeRecordingsOneSkippedLine_ThirtySixPercent()
 		{
 			const int kChapter = 1;
 			string chapterFolder = _bookInfo.GetChapterFolder(kChapter);
@@ -535,6 +535,29 @@ namespace HearThisTests
 			_psp.GetBlock(7, kChapter, 3).Skipped = true;
 
 			Assert.AreEqual(36, info.CalculatePercentageRecorded());
+		}
+
+		[Test]
+		public void CalculatePercentageRecorded_NoRecordingsOneSkippedLine_ZeroPercent()
+		{
+			const int kChapter = 1;
+			ChapterInfo info = CreateChapterInfo(kChapter);
+
+			_psp.GetBlock(7, kChapter, 3).Skipped = true;
+
+			Assert.AreEqual(0, info.CalculatePercentageRecorded());
+		}
+
+		[Test]
+		public void CalculatePercentageRecorded_AllLinesSkipped_100Percent()
+		{
+			const int kChapter = 1;
+			ChapterInfo info = CreateChapterInfo(kChapter);
+
+			for (int i = 0; i < _psp.GetScriptBlockCount(7, kChapter); i++)
+				_psp.GetBlock(7, kChapter, i).Skipped = true;
+
+			Assert.AreEqual(100, info.CalculatePercentageRecorded());
 		}
 
 		[Test]

--- a/src/HearThisTests/ChapterInfoTests.cs
+++ b/src/HearThisTests/ChapterInfoTests.cs
@@ -534,7 +534,14 @@ namespace HearThisTests
 
 			_psp.GetBlock(7, kChapter, 3).Skipped = true;
 
-			Assert.AreEqual(36, info.CalculatePercentageRecorded());
+			try
+			{
+				Assert.AreEqual(36, info.CalculatePercentageRecorded());
+			}
+			finally
+			{
+				_psp.GetBlock(7, kChapter, 3).Skipped = false;
+			}
 		}
 
 		[Test]
@@ -545,7 +552,14 @@ namespace HearThisTests
 
 			_psp.GetBlock(7, kChapter, 3).Skipped = true;
 
-			Assert.AreEqual(0, info.CalculatePercentageRecorded());
+			try
+			{
+				Assert.AreEqual(0, info.CalculatePercentageRecorded());
+			}
+			finally
+			{
+				_psp.GetBlock(7, kChapter, 3).Skipped = false;
+			}
 		}
 
 		[Test]
@@ -557,7 +571,15 @@ namespace HearThisTests
 			for (int i = 0; i < _psp.GetScriptBlockCount(7, kChapter); i++)
 				_psp.GetBlock(7, kChapter, i).Skipped = true;
 
-			Assert.AreEqual(100, info.CalculatePercentageRecorded());
+			try
+			{
+				Assert.AreEqual(100, info.CalculatePercentageRecorded());
+			}
+			finally
+			{
+				for (int i = 0; i < _psp.GetScriptBlockCount(7, kChapter); i++)
+					_psp.GetBlock(7, kChapter, i).Skipped = false;
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
Only count skips toward percentage that a chapter is recorded if something has been recorded or everything is skipped

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/277)
<!-- Reviewable:end -->
