### PR TITLE
Make improvements related to Paratext versioning:

### DIFF
--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -98,10 +98,10 @@ the recorded files to that format, if necessary.
 - Added support for latest version of Glyssen script files.
 
 ## 27 February 2018
-- Update to work with latest version of Paratext 8 project data.
+- Update to work with latest version of Paratext 8 (and later) project data.
 
 ## 3 January 2018
-- Fixed bug to add support for transliterated text (in \tl field). This change was incorporated into product for both Paratext 7 and Paratext 8.
+- Fixed bug to add support for transliterated text (in \tl field).
 
 ## HearThis 2.0
 - Dramatic Reading support. You can now do dramatized recordings. Use [Glyssen](https://software.sil.org/glyssen/) to prepare a script based on your Paratext project, then export a "Glyssen Script". Double-click on that file to open it with HearThis. Each "actor" can then select their name, see the acting roles they have been given, and select one. HearThis will then walk them through recording the script for that role.
@@ -110,17 +110,17 @@ the recorded files to that format, if necessary.
 - We've cleaned up the normal color scheme a bit and given it a higher contrast than before.
 - There has always been an icon that shows you what device HearThis is listening to. We've added new icons to make that clearer, including a "warning"-looking one if HearThis detects that you are using a laptop's built-in microphone.
 - If you click the device icon, HearThis will now open the Windows Control Panel that lets you change to a different default recording device.
-- To use with Paratext, you must have Paratext 8
+- To use with Paratext, you must have Paratext 8 or later.
 
 
 ## February 2017
 Fixed bug that cause HearThis to crash when not connected to the Internet.
 
 ## January 2017
-Added support for recording passages of poetry in which you want to separate text at paragraph markers, instead of just punctuation. See Settings:Punctuation. This change was incorporated into both 1.4 (for Paratext 7) and 1.5 (for Paratext 8).
+Added support for recording passages of poetry in which you want to separate text at paragraph markers, instead of just punctuation. See Settings:Punctuation.
 
 ## 1.5 November 2016
-Added support for Paratext 8 projects. HearThis 1.4.x should be used for Paratext 7 projects.
+Added support for Paratext 8 projects.
 
 ## 1.4 September 2016
 Increased time we wait for external audio merger/converters to finish, from 1 minute to 10 minutes.

--- a/build/build.proj
+++ b/build/build.proj
@@ -153,10 +153,6 @@
 		<FileUpdate File="$(RootDir)\output\Installer\HearThisInstaller.$(Version).download_info"
 			Regex='_BUILD'
 			ReplacementText ="$(BUILD_NUMBER)" />
-		<!-- The CHANNEL gets saved as the "stability", which is really something else. -->
-		<FileUpdate File="$(RootDir)\output\Installer\HearThisInstaller.$(Version).download_info"
-			Regex='_CHANNEL_'
-			ReplacementText ="for Paratext 8" /> <!-- (or later) -->
 			
 		<FileUpdate File="$(RootDir)\output\releasenotes.download_info"
 			DatePlaceHolder='_DATE_'

--- a/src/HearThis/UI/ChooseProject.cs
+++ b/src/HearThis/UI/ChooseProject.cs
@@ -260,12 +260,21 @@ namespace HearThis.UI
 			{
 				dlg.ShowNewFolderButton = false;
 				var defaultFolder = Settings.Default.UserSpecifiedParatext8ProjectsDir;
+
+				if (IsNullOrWhiteSpace(defaultFolder) || !Directory.Exists(defaultFolder))
+					defaultFolder = Empty;
 #if !__MonoCS__
-				if (IsNullOrWhiteSpace(defaultFolder))
-					defaultFolder = @"c:\My Paratext 8 Projects";
+				if (defaultFolder == Empty)
+				{
+					defaultFolder = new[]
+					{
+						@"c:\My Paratext 8 Projects",
+						@"c:\My Paratext 9 Projects",
+						@"c:\My Paratext Projects"
+					}.FirstOrDefault(Directory.Exists) ?? Empty;
+				}
 #endif
-				if (!IsNullOrWhiteSpace(defaultFolder) && Directory.Exists(defaultFolder))
-					dlg.SelectedPath = defaultFolder;
+				dlg.SelectedPath = defaultFolder;
 
 				dlg.Description = LocalizationManager.GetString("ChooseProject.FindParatextProjectsFolder",
 					"Find Paratext projects folder", "Displayed in folder browser dialog (only accessible if Paratext is not installed).");

--- a/src/Installer/template.download_info
+++ b/src/Installer/template.download_info
@@ -5,7 +5,7 @@
   "platform": "win",
   "platform_version": "",
   "architecture": "x64",
-  "stability": "_CHANNEL_",
+  "stability": "release",
   "file": "HearThisInstaller-_VERSION_.exe",
   "md5": "",
   "type": "msi",


### PR DESCRIPTION
Changed build to no longer create download info files with specific Paratext version references. Changed specific references to Paratext 8 in ReleaseNotes to also include later versions. Removed potentially confusing references to Paratext 7 (no longer supported) from ReleaseNotes. Changed logic in Find Paratext Projects Folder dialog to try to find any of the "standard" Paratext Project locations that might exist to use as default location

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/290)
<!-- Reviewable:end -->
