### PR TITLE
HT-489: Hide "Record long lines in parts" button at end of chapter

### DIFF
--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -225,7 +225,7 @@ namespace HearThis.UI
 			if (recordingDeviceButton1.Recorder.SelectedDevice == null)
 			{
 				ReportNoMicrophone(null, null);
-				// Note: We we used to immediately kill HearThis if no recording device was found,
+				// Note: We used to immediately kill HearThis if no recording device was found,
 				// but this seems unnecessarily extreme. Give them a chance to hook up a mic. Even
 				// if they don't, they could publish existing stuff or review existing recordings.
 				//Environment.Exit(1);
@@ -1155,6 +1155,7 @@ namespace HearThis.UI
 
 			_nextChapterLink.Text = Format(_gotoLink, GetNextChapterLabel());
 			_nextChapterLink.Visible = true;
+			_recordInPartsButton.Hide();
 		}
 
 		private void ShowEndOfUnit(string text)
@@ -1177,6 +1178,7 @@ namespace HearThis.UI
 			{
 				_scriptControl.Visible = true;
 				_audioButtonsControl.CanGoNext = true;
+				_recordInPartsButton.Show();
 			}
 			else
 			{

--- a/src/HearThis/UI/Shell.cs
+++ b/src/HearThis/UI/Shell.cs
@@ -1003,7 +1003,7 @@ namespace HearThis.UI
 		{
 			var menuItem = sender as ToolStripDropDownButton;
 			if (menuItem == null || menuItem.HasDropDownItems == false)
-				return; // not a drop down item
+				return; // not a dropdown item
 			// Current bounds of the current monitor
 			var upperRightCornerOfMenuInScreenCoordinates = menuItem.GetCurrentParent().PointToScreen(new Point(menuItem.Bounds.Right, menuItem.Bounds.Top));
 			var currentScreen = Screen.FromPoint(upperRightCornerOfMenuInScreenCoordinates);


### PR DESCRIPTION
This prevents a crash when "Record long lines in parts" button is showing but there is no current script line

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/311)
<!-- Reviewable:end -->
