### PR TITLE
Removed unnecessary binding redirects for System DLLs from test app.config file

### DIFF
--- a/src/HearThisTests/app.config
+++ b/src/HearThisTests/app.config
@@ -31,10 +31,6 @@
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="SIL.Core.Desktop" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
@@ -49,10 +45,6 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Win32.Registry" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Configuration.ConfigurationManager" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
These unnecessary binding redirects seem to cause test failures for some developers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/314)
<!-- Reviewable:end -->
