### PR TITLE
HT-496: Prevented incorrect "Cannot check validity of nonexistent file" scenario

### DIFF
--- a/src/HearThis/Publishing/ClipRepository.cs
+++ b/src/HearThis/Publishing/ClipRepository.cs
@@ -249,10 +249,10 @@ namespace HearThis.Publishing
 
 				// This happened during an operation (e.g., publishing) that is likely processing
 				// lots of files and therefore could be using a collection of files that no longer
-				// matches what is on disk. publishing. Though unexpected, perhaps the user or some
-				// other clean-up process already got rid of this file. We were just going to
-				// delete it if it was invalid anyway, so let's just log the oddity and report it
-				// as though we deleted it.
+				// matches what is on disk. Though unexpected, perhaps the user or some other
+				// clean-up process already got rid of this file. We were just going to delete it
+				// if it was invalid anyway, so let's just log the oddity and report it as though
+				// we deleted it.
 				progress.WriteWarning(LocalizationManager.GetString(
 					"ClipRepository.ClipNoLongerExistsWarning",
 					"Attempted to check validity of nonexistent file: {0}"), filename);

--- a/src/HearThis/Publishing/ClipRepository.cs
+++ b/src/HearThis/Publishing/ClipRepository.cs
@@ -27,6 +27,7 @@ using NAudio.Wave;
 using static System.Int32;
 using static System.IO.Path;
 using static System.String;
+using static HearThis.Program;
 using static HearThis.Script.ParatextScriptProvider;
 
 namespace HearThis.Publishing
@@ -204,7 +205,7 @@ namespace HearThis.Publishing
 
 		public static string GetProjectFolder(string projectName)
 		{
-			return Program.GetApplicationDataFolder(projectName);
+			return GetApplicationDataFolder(projectName);
 		}
 
 		public static int GetCountOfRecordingsInFolder(string path, IScriptProvider scriptProvider)
@@ -231,10 +232,37 @@ namespace HearThis.Publishing
 		/// Checks to see whether the given file is not a valid WAV file. If it isn't,
 		/// it deletes it.
 		/// </summary>
+		/// <returns><c>true</c> if the file was invalid (or -- if progress is set -- if it is
+		/// missing); <c>false</c>, otherwise.</returns>
 		public static bool IsInvalidClipFile(string filename, IProgress progress = null)
 		{
+			if (IsNullOrEmpty(filename))
+				throw new ArgumentNullException(nameof(filename));
+
 			if (!File.Exists(filename))
-				throw new FileNotFoundException("Cannot check validity of nonexistent file", filename);
+			{
+				if (progress == null)
+				{
+					throw new FileNotFoundException(
+						$"Cannot check validity of nonexistent file: {filename}", filename);
+				}
+
+				// This happened during an operation (e.g., publishing) that is likely processing
+				// lots of files and therefore could be using a collection of files that no longer
+				// matches what is on disk. publishing. Though unexpected, perhaps the user or some
+				// other clean-up process already got rid of this file. We were just going to
+				// delete it if it was invalid anyway, so let's just log the oddity and report it
+				// as though we deleted it.
+				progress.WriteWarning(LocalizationManager.GetString(
+					"ClipRepository.ClipNoLongerExistsWarning",
+					"Attempted to check validity of nonexistent file: {0}"), filename);
+				Analytics.Track("Clip not found while publishing", new Dictionary<string, string>
+				{
+					{"filename", filename}
+				});
+				return true;
+			}
+
 			try
 			{
 				using (var _ = new WaveFileReader(filename))
@@ -247,7 +275,7 @@ namespace HearThis.Publishing
 					"Param 0: WAV file name; " +
 					"Param 1: Error message; " +
 					"Param 2: \"HearThis\" (product name)"),
-					filename, e.Message, Program.kProduct);
+					filename, e.Message, kProduct);
 				Logger.WriteEvent(msg);
 				progress?.WriteError(msg);
 			}
@@ -295,7 +323,7 @@ namespace HearThis.Publishing
 
 		public static bool HasRecordingsForProject(string projectName)
 		{
-			return Directory.GetDirectories(Program.GetApplicationDataFolder(projectName))
+			return Directory.GetDirectories(GetApplicationDataFolder(projectName))
 				.Any(bookDirectory => GetNumericDirectories(bookDirectory).Any(chDirectory => GetSoundFilesInFolder(chDirectory).Length > 0));
 		}
 
@@ -365,28 +393,32 @@ namespace HearThis.Publishing
 		public static bool UndeleteLineRecording(string projectName, BookInfo book,
 			ChapterInfo chapterInfo, int lineNumber)
 		{
-			string bookName = book.Name;
+			var bookName = book.Name;
 			int chapterNumber = chapterInfo.ChapterNumber1Based;
 			if (HasClipUnfiltered(projectName, bookName, chapterNumber, lineNumber))
 				return false; // At least for now, do not allow overwriting current clip.
 
 			var path = GetPathToLineRecordingUnfiltered(projectName, bookName, chapterNumber, lineNumber);
 			var backupPath = ChangeExtension(path, kBackupFileExtension);
-			if (!File.Exists(backupPath))
-				return false;
+
+			var deletedScriptLine = book.GetUnfilteredBlock(chapterNumber, lineNumber);
 			try
 			{
 				RobustFile.Move(backupPath, path);
-				chapterInfo.OnClipUndeleted(book.GetUnfilteredBlock(chapterNumber, lineNumber));
+				chapterInfo.OnClipUndeleted(deletedScriptLine);
 				return true;
 			}
-			catch (IOException err)
+			catch (Exception e)
 			{
-				ErrorReport.NotifyUserOfProblem(err,
-					Format(LocalizationManager.GetString("ClipRepository.UndeleteClipProblem",
-						"HearThis was unable to restore this deleted clip. File may be locked. Restarting HearThis might solve this problem. File: {0}"), backupPath));
+				if (deletedScriptLine != null &&
+				    (e is FileNotFoundException || e is InvalidFileException))
+				{
+					chapterInfo.DeletedRecordings.Remove(deletedScriptLine);
+					chapterInfo.Save();
+				}
+
+				throw;
 			}
-			return false;
 		}
 
 		/// <summary>
@@ -517,7 +549,7 @@ namespace HearThis.Publishing
 					file.Delete();
 			}
 
-			// Saving has a side-effect of removing any orphaned (not corresponding to a WAV file)
+			// Saving has a side effect of removing any orphaned (not corresponding to a WAV file)
 			// recording info entries beyond the last known block.
 			chapter.Save();
 		}
@@ -590,7 +622,7 @@ namespace HearThis.Publishing
 
 					var msg = Format(LocalizationManager.GetString("ClipRepository.BothSkipAndClipExist",
 						"{0} found an existing clip for a block that was marked as being skipped.",
-							"Low-priority for localization. Param 0: \"HearThis\" (product name)"), Program.kProduct);
+							"Low-priority for localization. Param 0: \"HearThis\" (product name)"), kProduct);
 
 					if (skipWriteTime.CompareTo(clipWriteTime) > 0)
 					{
@@ -641,7 +673,7 @@ namespace HearThis.Publishing
 		/// <see cref="iBlock"/>, all the remaining clips will be shifted. This might include
 		/// clips that are "extras" (beyond the clips accounted for by the source text).</param>
 		/// <param name="offset">The number of positions to shift clips forward (positive) or
-		/// backward (negative). A value of 0 is not an error but it results in no change.</param>
+		/// backward (negative). A value of 0 is not an error, but it results in no change.</param>
 		/// <param name="getRecordingInfo">A function to get the recording information for the
 		/// chapter specified by <see cref="chapterNumber1Based"/>.</param>
 		/// <returns>A result indicating the actual number of clips that were attempted to be
@@ -776,7 +808,7 @@ namespace HearThis.Publishing
 				return;
 			}
 
-			var bookNames = new List<string>(Directory.GetDirectories(Program.GetApplicationDataFolder(projectName)).Select(GetFileName));
+			var bookNames = new List<string>(Directory.GetDirectories(GetApplicationDataFolder(projectName)).Select(GetFileName));
 			bookNames.Sort(publishingModel.PublishingInfoProvider.BookNameComparer);
 
 			foreach (var bookName in bookNames)
@@ -813,7 +845,7 @@ namespace HearThis.Publishing
 
 		public static bool GetDoAnyClipsExistForProject(string projectName)
 		{
-			return Directory.GetFiles(Program.GetApplicationDataFolder(projectName), "*.wav", SearchOption.AllDirectories).Any();
+			return Directory.GetFiles(GetApplicationDataFolder(projectName), "*.wav", SearchOption.AllDirectories).Any();
 		}
 
 		public static bool GetDoAnyClipsExistInChapter(string projectName, string bookName, int chapter)

--- a/src/HearThis/Script/ChapterInfo.cs
+++ b/src/HearThis/Script/ChapterInfo.cs
@@ -424,11 +424,26 @@ namespace HearThis.Script
 			return XmlSerializationHelper.SerializeToString(this);
 		}
 
-		public override void OnScriptBlockRecorded(ScriptLine selectedScriptBlock,
-			Func<Exception, bool> exceptionOverride = null)
+		/// <summary>
+		/// This method is called when a script block is recorded, restored from a backup, or moved
+		/// into a new position. In response, it first checks to ensure the file is present and
+		/// valid, and then it updates the information in the persisted ChapterInfo file.
+		/// </summary>
+		/// <param name="scriptBlock">The script block whose recorded clip file was just recorded,
+		/// restored, etc.</param>
+		/// <param name="exceptionHandlerOverride">By default, invalid/corrupted clip files are
+		/// logged and deleted. If the clip file is not found at all, it is reported to the user as
+		/// a non-fatal error. If there is a need to handle other exception cases, alert the user
+		/// to an invalid file, do something special to reset the UI in the case of an exception,
+		/// etc., the caller should set this parameter, providing a function that handles the
+		/// exception appropriately and then returns <c>true</c> to indicate that no further
+		/// handling is needed or <c>false</c> to request that the default handling also be
+		/// performed.</param>
+		public override void OnScriptBlockRecorded(ScriptLine scriptBlock,
+			Func<Exception, bool> exceptionHandlerOverride = null)
 		{
 			var filename = ClipRepository.GetPathToLineRecording(_projectName, _bookName,
-				ChapterNumber1Based, selectedScriptBlock.Number - 1);
+				ChapterNumber1Based, scriptBlock.Number - 1);
 			try
 			{
 				if (ClipRepository.IsInvalidClipFile(filename))
@@ -436,13 +451,22 @@ namespace HearThis.Script
 			}
 			catch (Exception e)
 			{
-				if (exceptionOverride != null)
+				if (exceptionHandlerOverride != null)
 				{
-					if (exceptionOverride(e))
+					if (exceptionHandlerOverride(e))
 						return; // Caller handled the exception.
 				}
+
 				if (e is InvalidFileException)
+				{
+					// If the file was invalid, the problem will already have been logged and the
+					// bogus file will have been deleted inside ClipRepository.IsInvalidClipFile.
+					// Many of the callers to this method already have code in place that updates
+					// the UI based on the presence or absence of a recording, so nothing more need
+					// be done. (See comment for exceptionHandlerOverride parameter.)
 					return;
+				}
+
 				if (e is FileNotFoundException)
 				{
 					// Something bad/weird probably happened, and we hope the user will report it (or
@@ -454,30 +478,30 @@ namespace HearThis.Script
 
 				throw;
 			}
-			selectedScriptBlock.Skipped = false;
-			Debug.Assert(selectedScriptBlock.Number > 0);
+			scriptBlock.Skipped = false;
+			Debug.Assert(scriptBlock.Number > 0);
 			int iInsert = 0;
 			for (int i = 0; i < Recordings.Count; i++)
 			{
 				var recording = Recordings[i];
-				if (recording.Number == selectedScriptBlock.Number)
+				if (recording.Number == scriptBlock.Number)
 				{
-					Recordings[i] = selectedScriptBlock;
+					Recordings[i] = scriptBlock;
 					iInsert = -1;
 					break;
 				}
-				if (recording.Number > selectedScriptBlock.Number)
+				if (recording.Number > scriptBlock.Number)
 				{
 					break;
 				}
 				iInsert++;
 			}
 			if (iInsert >= 0)
-				Recordings.Insert(iInsert, selectedScriptBlock);
+				Recordings.Insert(iInsert, scriptBlock);
 			if (DeletedRecordings != null)
 			{
 				// There should never be more than one.
-				DeletedRecordings.RemoveAll(s => s.Number == selectedScriptBlock.Number);
+				DeletedRecordings.RemoveAll(s => s.Number == scriptBlock.Number);
 			}
 			Save();
 		}

--- a/src/HearThis/Script/ChapterRecordingInfoBase.cs
+++ b/src/HearThis/Script/ChapterRecordingInfoBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using static System.Int32;
 
@@ -22,7 +23,8 @@ namespace HearThis.Script
 			Save(preserveModifiedTime);
 		}
 
-		public abstract void OnScriptBlockRecorded(ScriptLine selectedScriptBlock);
+		public abstract void OnScriptBlockRecorded(ScriptLine selectedScriptBlock,
+			Func<Exception, bool> exceptionOverride = null);
 
 		public abstract void Save(bool preserveModifiedTime = false);
 	}

--- a/src/HearThis/Script/ChapterRecordingInfoBase.cs
+++ b/src/HearThis/Script/ChapterRecordingInfoBase.cs
@@ -23,8 +23,20 @@ namespace HearThis.Script
 			Save(preserveModifiedTime);
 		}
 
-		public abstract void OnScriptBlockRecorded(ScriptLine selectedScriptBlock,
-			Func<Exception, bool> exceptionOverride = null);
+		/// <summary>
+		/// This method is called when a script block is recorded, restored from a backup, or moved
+		/// into a new position.
+		/// </summary>
+		/// <param name="scriptBlock">The script block whose recorded clip file was just recorded,
+		/// restored, etc.</param>
+		/// <param name="exceptionHandlerOverride">If there is a need to handle exceptions in a
+		/// manner other than the default behavior (which should be described by specific
+		/// implementers), the caller should set this parameter, providing a function that handles
+		/// the exception appropriately and then returns <c>true</c> to indicate that no further
+		/// handling is needed or <c>false</c> to request that the default handling also be
+		/// performed.</param>
+		public abstract void OnScriptBlockRecorded(ScriptLine scriptBlock,
+			Func<Exception, bool> exceptionHandlerOverride = null);
 
 		public abstract void Save(bool preserveModifiedTime = false);
 	}

--- a/src/HearThis/Script/InvalidFileException.cs
+++ b/src/HearThis/Script/InvalidFileException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace HearThis.Script
+{
+	public class InvalidFileException : Exception
+	{
+		public string Filename { get; }
+
+		public InvalidFileException(string message, string filename) : base(message)
+		{
+			Filename = filename;
+		}
+	}
+}

--- a/src/HearThis/Script/Project.cs
+++ b/src/HearThis/Script/Project.cs
@@ -17,8 +17,12 @@ using System.Text;
 using DesktopAnalytics;
 using HearThis.Properties;
 using HearThis.Publishing;
+using L10NSharp;
 using SIL.IO;
+using SIL.Reporting;
 using static HearThis.Script.BibleStatsBase;
+using static HearThis.Program;
+using static System.String;
 
 namespace HearThis.Script
 {
@@ -618,16 +622,52 @@ namespace HearThis.Script
 			return false;
 		}
 
-		public bool UndeleteClipForSelectedBlock()
+		public bool RestoreClipForSelectedBlock(bool suppressSideEffects = false)
 		{
-			if (ClipRepository.UndeleteLineRecording(Name, SelectedBook, SelectedChapterInfo,
-				SelectedScriptBlock))
+			var restored = false;
+			try
 			{
-				ScriptBlockRecordingRestored?.Invoke(this, SelectedBook.BookNumber, SelectedChapterInfo.ChapterNumber1Based, ScriptOfSelectedBlock);
-				return true;
+				restored = ClipRepository.UndeleteLineRecording(Name, SelectedBook, SelectedChapterInfo,
+					SelectedScriptBlock);
+			}
+			catch (Exception ex)
+			{
+				string fmt;
+				switch (ex)
+				{
+					case FileNotFoundException _:
+						fmt = LocalizationManager.GetString("ClipRepository.RestoreFileNotFound",
+							"{0} was unable to restore the clip because the backup was missing. " +
+							"Sorry.", "Param is \"HearThis\" (product name)");
+						break;
+					case IOException _:
+						fmt = LocalizationManager.GetString("ClipRepository.UndeleteClipProblem",
+							"{0} was unable to restore the clip. If the backup file was " +
+							"locked, restarting {0} might solve this problem.",
+							"Param is \"HearThis\" (product name)");
+						break;
+					case InvalidFileException _:
+						fmt = LocalizationManager.GetString(
+							"ClipRepository.RestoredFileWasInvalidClip",
+							"When restoring the deleted file, {0} determined that it was not a " +
+							"valid clip, so it was removed. Sorry.",
+							"Param is \"HearThis\" (product name)");
+						break;
+					default:
+						throw;
+				}
+
+				if (!suppressSideEffects)
+					ErrorReport.NotifyUserOfProblem(ex, Format(fmt, kProduct));
 			}
 
-			return false;
+			if (restored && !suppressSideEffects)
+			{
+				ScriptBlockRecordingRestored?.Invoke(this, SelectedBook.BookNumber,
+					SelectedChapterInfo.ChapterNumber1Based, ScriptOfSelectedBlock);
+			}
+
+			return restored;
 		}
 
 		public List<ScriptLine> GetRecordableBlocksUpThroughNextHoleToTheRight()
@@ -713,10 +753,12 @@ namespace HearThis.Script
 				currentScriptLine.Actor = currentScriptLine.Character = null;
 			}
 			currentScriptLine.RecordingTime = DateTime.UtcNow;
-			SelectedChapterInfo.OnScriptBlockRecorded(currentScriptLine);
-
-			if (clipPath != null && !File.Exists(clipPath))
-				throw new FileNotFoundException("Corrupted file deleted", clipPath);
+			SelectedChapterInfo.OnScriptBlockRecorded(currentScriptLine, exception =>
+			{
+				if (exception is FileNotFoundException)
+					throw exception;
+				return false;
+			});
 		}
 
 		private void DeleteClipsBeyondLastClip()
@@ -747,12 +789,6 @@ namespace HearThis.Script
 		{
 			return ClipRepository.HasBackupFile(Name, SelectedBook.Name,
 				SelectedChapterInfo.ChapterNumber1Based, SelectedScriptBlock);
-		}
-
-		public bool UndeleteLineRecordingForSelectedBlock()
-		{
-			return ClipRepository.UndeleteLineRecording(Name,
-				SelectedBook, SelectedChapterInfo, SelectedScriptBlock);
 		}
 	}
 }

--- a/src/HearThis/UI/MouseSensitiveIconButton.cs
+++ b/src/HearThis/UI/MouseSensitiveIconButton.cs
@@ -119,5 +119,12 @@ namespace HearThis.UI
 			if (CorrespondingRadioButton != null)
 				CorrespondingRadioButton.Visible = Visible;
 		}
+
+		protected override void OnEnabledChanged(EventArgs e)
+		{
+			base.OnEnabledChanged(e);
+			if (CorrespondingRadioButton != null)
+				CorrespondingRadioButton.Enabled = Enabled;
+		}
 	}
 }

--- a/src/HearThis/UI/RecordingToolControl.cs
+++ b/src/HearThis/UI/RecordingToolControl.cs
@@ -975,7 +975,7 @@ namespace HearThis.UI
 		{
 			if (_currentMode == Mode.ReadAndRecord)
 			{
-				if (_project.UndeleteClipForSelectedBlock())
+				if (_project.RestoreClipForSelectedBlock())
 					OnSoundFileCreatedOrDeleted();
 			}
 			else

--- a/src/HearThisTests/ClipRepositoryTests.cs
+++ b/src/HearThisTests/ClipRepositoryTests.cs
@@ -8,13 +8,14 @@ using HearThis.Publishing;
 using HearThis.Script;
 using NUnit.Framework;
 using SIL.IO;
+using SIL.Progress;
 using SIL.Reporting;
 using DateTime = System.DateTime;
 
 namespace HearThisTests
 {
 	[TestFixture]
-	public partial class ClipRepositoryTests
+	public class ClipRepositoryTests
 	{
 		private const double kMonoSampleDuration = 0.062;
 		private TestErrorReporter _errorReporter;
@@ -265,6 +266,31 @@ namespace HearThisTests
 			{
 				RobustIO.DeleteDirectoryAndContents(ClipRepository.GetProjectFolder(projectName));
 			}
+		}
+
+		[TestCase(null)]
+		[TestCase("")]
+		public void IsInvalidClipFile_NullOrEmpty_ThrowsArgumentNullException(string path)
+		{
+			Assert.That(() => ClipRepository.IsInvalidClipFile(path), Throws.ArgumentNullException);
+		}
+
+		[Test]
+		public void IsInvalidClipFile_NonexistentFileWithProgress_LogsWarningAndReturnsTrue()
+		{
+			const string kFilename = "some_nonexistent_file.wav";
+			var progress = new StringBuilderProgress();
+			Assert.That(ClipRepository.IsInvalidClipFile(kFilename, progress), Is.True);
+			Assert.That(progress.Text.Trim('\r', '\n'), Is.EqualTo(
+				$"Warning: Attempted to check validity of nonexistent file: {kFilename}"));
+		}
+
+		[Test]
+		public void IsInvalidClipFile_NonexistentFileWithoutProgress_ThrowsFileNotFoundException()
+		{
+			const string kFilename = "some_nonexistent_file.wav";
+			Assert.That(() => ClipRepository.IsInvalidClipFile(kFilename),
+				Throws.TypeOf<FileNotFoundException>().With.Property("FileName").EqualTo(kFilename));
 		}
 
 		/// <summary>
@@ -2174,7 +2200,8 @@ namespace HearThisTests
 
 			public override IReadOnlyList<ScriptLine> RecordingInfo => _recordings;
 
-			public override void OnScriptBlockRecorded(ScriptLine selectedScriptBlock)
+			public override void OnScriptBlockRecorded(ScriptLine selectedScriptBlock,
+				Func<Exception, bool> exceptionOverride = null)
 			{
 				throw new NotImplementedException();
 			}

--- a/src/HearThisTests/ClipRepositoryTests.cs
+++ b/src/HearThisTests/ClipRepositoryTests.cs
@@ -2200,8 +2200,13 @@ namespace HearThisTests
 
 			public override IReadOnlyList<ScriptLine> RecordingInfo => _recordings;
 
-			public override void OnScriptBlockRecorded(ScriptLine selectedScriptBlock,
-				Func<Exception, bool> exceptionOverride = null)
+			/// <summary>
+			/// This is not expected to be called in these tests, but it is required by the
+			/// interface.
+			/// </summary>
+			/// <exception cref="NotImplementedException">Always</exception>
+			public override void OnScriptBlockRecorded(ScriptLine scriptBlock,
+				Func<Exception, bool> exceptionHandlerOverride = null)
 			{
 				throw new NotImplementedException();
 			}

--- a/src/HearThisTests/ScriptProviderBaseTests.cs
+++ b/src/HearThisTests/ScriptProviderBaseTests.cs
@@ -795,7 +795,8 @@ namespace HearThisTests
 
 			public override IReadOnlyList<ScriptLine> RecordingInfo => _recordings;
 
-			public override void OnScriptBlockRecorded(ScriptLine scriptBlock)
+			public override void OnScriptBlockRecorded(ScriptLine scriptBlock,
+				Func<Exception, bool> exceptionOverride = null)
 			{
 				if (_recordings.Any(r => r.Number >= scriptBlock.Number))
 					throw new InvalidOperationException("For these tests, simulate recording blocks in order");

--- a/src/HearThisTests/ScriptProviderBaseTests.cs
+++ b/src/HearThisTests/ScriptProviderBaseTests.cs
@@ -796,11 +796,13 @@ namespace HearThisTests
 			public override IReadOnlyList<ScriptLine> RecordingInfo => _recordings;
 
 			public override void OnScriptBlockRecorded(ScriptLine scriptBlock,
-				Func<Exception, bool> exceptionOverride = null)
+				Func<Exception, bool> exceptionHandlerOverride = null)
 			{
 				if (_recordings.Any(r => r.Number >= scriptBlock.Number))
 					throw new InvalidOperationException("For these tests, simulate recording blocks in order");
 				_recordings.Add(scriptBlock);
+				Assert.That(exceptionHandlerOverride, Is.Null,
+					"For these tests, no special exception handling is expected");
 			}
 
 			public override void Save(bool preserveModifiedTime = false)

--- a/src/HearThisTests/TestErrorReporter.cs
+++ b/src/HearThisTests/TestErrorReporter.cs
@@ -5,62 +5,60 @@ using SIL.Reporting;
 
 namespace HearThisTests
 {
-	public partial class ClipRepositoryTests
+	public class TestErrorReporter : IErrorReporter
 	{
-		internal class TestErrorReporter : IErrorReporter
+		internal class ReportedErrorInfo
 		{
-			internal class ReportedErrorInfo
-			{
-				public Exception Exception;
-				public string Message;
-			}
+			public Exception Exception;
+			public string Message;
+		}
 
-			private readonly List<ReportedErrorInfo> _reportedProblems = new List<ReportedErrorInfo>();
+		private readonly List<ReportedErrorInfo> _reportedProblems = new List<ReportedErrorInfo>();
 
-			internal IReadOnlyList<ReportedErrorInfo> ReportedProblems => _reportedProblems;
+		internal IReadOnlyList<ReportedErrorInfo> ReportedProblems => _reportedProblems;
 
-			public void ReportFatalException(Exception e)
-			{
-				throw e;
-			}
+		public void ReportFatalException(Exception e)
+		{
+			throw e;
+		}
 
-			public void NotifyUserOfProblem(IRepeatNoticePolicy policy, Exception exception, string message)
-			{
-				_reportedProblems.Add(new ReportedErrorInfo {Exception = exception, Message = message });
-			}
+		public void NotifyUserOfProblem(IRepeatNoticePolicy policy, Exception exception, string message)
+		{
+			_reportedProblems.Add(new ReportedErrorInfo { Exception = exception, Message = message });
+		}
 
-			public ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy, string alternateButton1Label, ErrorResult resultIfAlternateButtonPressed, string message)
-			{
-				if (policy == null || policy.ShouldShowMessage(message))
-					_reportedProblems.Add(new ReportedErrorInfo { Message = message });
-
-				return resultIfAlternateButtonPressed;
-			}
-
-			public void ReportNonFatalException(Exception exception, IRepeatNoticePolicy policy)
-			{
-				if (policy == null || policy.ShouldShowErrorReportDialog(exception))
-					_reportedProblems.Add(new ReportedErrorInfo { Exception = exception });
-			}
-
-			public void ReportNonFatalExceptionWithMessage(Exception error, string message, params object[] args)
-			{
-				if (args != null && args.Any())
-					message = string.Format(message, args);
-				_reportedProblems.Add(new ReportedErrorInfo { Exception = error, Message = message });
-			}
-
-			public void ReportNonFatalMessageWithStackTrace(string message, params object[] args)
-			{
-				if (args != null && args.Any())
-					message = string.Format(message, args);
+		public ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy, string alternateButton1Label,
+			ErrorResult resultIfAlternateButtonPressed, string message)
+		{
+			if (policy == null || policy.ShouldShowMessage(message))
 				_reportedProblems.Add(new ReportedErrorInfo { Message = message });
-			}
 
-			public void ReportFatalMessageWithStackTrace(string message, object[] args)
-			{
-				throw new Exception(message);
-			}
+			return resultIfAlternateButtonPressed;
+		}
+
+		public void ReportNonFatalException(Exception exception, IRepeatNoticePolicy policy)
+		{
+			if (policy == null || policy.ShouldShowErrorReportDialog(exception))
+				_reportedProblems.Add(new ReportedErrorInfo { Exception = exception });
+		}
+
+		public void ReportNonFatalExceptionWithMessage(Exception error, string message, params object[] args)
+		{
+			if (args != null && args.Any())
+				message = string.Format(message, args);
+			_reportedProblems.Add(new ReportedErrorInfo { Exception = error, Message = message });
+		}
+
+		public void ReportNonFatalMessageWithStackTrace(string message, params object[] args)
+		{
+			if (args != null && args.Any())
+				message = string.Format(message, args);
+			_reportedProblems.Add(new ReportedErrorInfo { Message = message });
+		}
+
+		public void ReportFatalMessageWithStackTrace(string message, object[] args)
+		{
+			throw new Exception(message);
 		}
 	}
 }


### PR DESCRIPTION

 Made handling of corrupt/missing files more robust.
Fixed several other minor errors in Check for Problems mode (e.g., displaying different for extra blocks).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/320)
<!-- Reviewable:end -->
