### PR TITLE
HT-495: Prevent IndexOutOfRangeException

### DIFF
--- a/src/HearThis/Script/Project.cs
+++ b/src/HearThis/Script/Project.cs
@@ -653,9 +653,13 @@ namespace HearThis.Script
 			var lines = new List<ScriptLine>();
 			foreach (var i in indices)
 			{
+				// Note: If we are filtered by character/actor, we break when we get to a block
+				// that is currently unrecordable (not for that character and assigned to that
+				// actor). See
+				// https://community.scripture.software.sil.org/t/how-to-deal-with-script-changes-in-a-multi-voice-recording-project/4862
 				if (!IsLineCurrentlyRecordable(bookInfo.BookNumber, chapter, i))
 					break;
-				var block = bookInfo.ScriptProvider.GetBlock(bookInfo.BookNumber, chapter, i);
+				var block = bookInfo.ScriptProvider.GetUnfilteredBlock(bookInfo.BookNumber, chapter, i);
 				if (block.Skipped)
 					break;
 


### PR DESCRIPTION
This could happen in a GlyssenScript project when using Shift Clips because we used the unfiltered block index to reference a block in a filtered collection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/322)
<!-- Reviewable:end -->
