### PR TITLE
Fix incorrect local IP address sometimes put in QR code

### DIFF
--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -39,6 +39,7 @@ the recorded files to that format, if necessary.
 ## _VERSION_ (_DATE_)
 - Improvements related to opening a clip for editing in an external program.
 - Updated localizations.
+- Improved connectivity with HearThisAndroid.
 
 ## 3.5.3 (March 2025)
 - Fixed bug affecting Glyssenscript projects when extra clips are present.

--- a/src/HearThis/Communication/AndroidSynchronization.cs
+++ b/src/HearThis/Communication/AndroidSynchronization.cs
@@ -95,9 +95,7 @@ namespace HearThis.Communication
 			public RoutingTableProxy()
 			{
 				_metricsByInterfaceIndex = new Dictionary<uint, int>();
-				Debug.WriteLine("SYNC_RTP, calling LoadRoutingTable()"); // TEMPORARY
 				LoadRoutingTable();
-				Debug.WriteLine("SYNC_RTP, LoadRoutingTable() complete"); // TEMPORARY
 			}
 
 			public bool IsValid()
@@ -134,10 +132,8 @@ namespace HearThis.Communication
 						Debug.WriteLine($"AndroidSynchronization, error ({result}) getting size");
 						throw new Win32Exception(result);
 					}
-					Debug.WriteLine($"SYNC_LRT, got size = {size}"); // TEMPORARY
 
 					RoutingTableBuf = Marshal.AllocHGlobal(size);
-					Debug.WriteLine("SYNC_LRT, allocated buffer"); // TEMPORARY
 
 					// Second call gets the table.
 					result = GetIpForwardTable(RoutingTableBuf, ref size, true);
@@ -156,23 +152,19 @@ namespace HearThis.Communication
 					int metric;
 					var table = Marshal.PtrToStructure<MIB_IPFORWARDTABLE>(RoutingTableBuf);
 					IntPtr rowPtr = IntPtr.Add(RoutingTableBuf, Marshal.OffsetOf<MIB_IPFORWARDTABLE>("route").ToInt32());
-					Debug.WriteLine($"SYNC_LRT, parse buffer ({table.dwNumEntries} entries) begin"); // TEMPORARY
 
 					for (int i = 0; i < table.dwNumEntries; i++)
 					{
 						MIB_IPFORWARDROW row = Marshal.PtrToStructure<MIB_IPFORWARDROW>(rowPtr);
-						Debug.WriteLine($"  i={i} index={row.dwForwardIfIndex} metric={row.dwForwardMetric1}"); // TEMPORARY
 
 						if (_metricsByInterfaceIndex.TryGetValue(row.dwForwardIfIndex, out metric) == false)
 						{
 							// meets criterion #1
-							Debug.WriteLine("    meets criterion #1, adding to dictionary"); // TEMPORARY
 							_metricsByInterfaceIndex[row.dwForwardIfIndex] = row.dwForwardMetric1;
 						}
 						else if (row.dwForwardMetric1 < metric)
 						{
 							// meets criterion #2
-							Debug.WriteLine("    meets criterion #2, adding to dictionary"); // TEMPORARY
 							_metricsByInterfaceIndex[row.dwForwardIfIndex] = row.dwForwardMetric1;
 						}
 						rowPtr = IntPtr.Add(rowPtr, Marshal.SizeOf<MIB_IPFORWARDROW>());
@@ -180,7 +172,6 @@ namespace HearThis.Communication
 
 					// Got through entire buffer without exception so say we're good.
 					Ready = true;
-					Debug.WriteLine("SYNC_LRT, parse buffer done, Ready=true"); // TEMPORARY
 				}
 				catch (Exception e)
 				{
@@ -191,15 +182,7 @@ namespace HearThis.Communication
 					if (RoutingTableBuf != IntPtr.Zero)
 					{
 						Marshal.FreeHGlobal(RoutingTableBuf);
-						Debug.WriteLine("SYNC_LRT, finally: released buffer"); // TEMPORARY
 					}
-					// DEBUG ONLY: dump the dictionary
-					Debug.WriteLine("SYNC_LRT, dump the dictionary:");
-					foreach (var item in _metricsByInterfaceIndex)
-					{
-						Debug.WriteLine($"  index={item.Key} metric={item.Value}");
-					}
-					// END DEBUG ONLY
 				}
 			}
 		}
@@ -384,12 +367,10 @@ namespace HearThis.Communication
 						if (ni.NetworkInterfaceType == NetworkInterfaceType.Wireless80211)
 						{
 							currentIfaceMetric = proxy.GetMetricForInterface(uIndex);
-							Debug.WriteLine($"GISWU, maybe: wifi, index={ipv4Props.Index}, metric={currentIfaceMetric}"); // TEMPORARY
 
 							// Save this interface if its metric is lowest we've seen so far.
 							if (currentIfaceMetric < wifiInterface.Metric)
 							{
-								Debug.WriteLine($"GISWU, new wifi candidate, index={ipv4Props.Index}, metric={currentIfaceMetric}"); // TEMPORARY
 								wifiInterface.IpAddr = ip.Address.ToString();
 								wifiInterface.Description = ni.Description;
 								wifiInterface.Metric = currentIfaceMetric;
@@ -398,12 +379,10 @@ namespace HearThis.Communication
 						else if (ni.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
 						{
 							currentIfaceMetric = proxy.GetMetricForInterface(uIndex);
-							Debug.WriteLine($"GISWU, maybe: ethernet, index={ipv4Props.Index}, metric={currentIfaceMetric}"); // TEMPORARY
 
 							// Save this interface if its metric is lowest we've seen so far.
 							if (currentIfaceMetric < ethernetInterface.Metric)
 							{
-								Debug.WriteLine($"GISWU, new ethernet candidate, index={ipv4Props.Index}, metric={currentIfaceMetric}"); // TEMPORARY
 								ethernetInterface.IpAddr = ip.Address.ToString();
 								ethernetInterface.Description = ni.Description;
 								ethernetInterface.Metric = currentIfaceMetric;

--- a/src/HearThis/Communication/AndroidSynchronization.cs
+++ b/src/HearThis/Communication/AndroidSynchronization.cs
@@ -21,6 +21,9 @@ using DesktopAnalytics;
 using L10NSharp;
 using SIL.Reporting;
 using static System.String;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using NDesk.DBus;
 
 namespace HearThis.Communication
 {
@@ -30,6 +33,63 @@ namespace HearThis.Communication
 	public static class AndroidSynchronization
 	{
 		private const string kHearThisAndroidProductName = "HearThis Android";
+
+		// Layout of a row in the IPv4 routing table.
+		[StructLayout(LayoutKind.Sequential)]
+		public struct MIB_IPFORWARDROW
+		{
+			public uint dwForwardDest;
+			public uint dwForwardMask;
+			public uint dwForwardPolicy;
+			public uint dwForwardNextHop;
+			public int dwForwardIfIndex;
+			public int dwForwardType;
+			public int dwForwardProto;
+			public int dwForwardAge;
+			public int dwForwardNextHopAS;
+			public int dwForwardMetric1;  // the "interface metric" we need
+			public int dwForwardMetric2;
+			public int dwForwardMetric3;
+			public int dwForwardMetric4;
+			public int dwForwardMetric5;
+		}
+
+		// Hold a copy of the IPv4 routing table, which we will examine
+		// to find which row/route has the lowest "interface metric".
+		[StructLayout(LayoutKind.Sequential)]
+		private struct MIB_IPFORWARDTABLE
+		{
+			private int dwNumEntries;
+			private MIB_IPFORWARDROW table;
+		}
+
+		// We use an unmanaged function in the C/C++ DLL "iphlpapi.dll".
+		//   - "true": calling this function *can* set an error code,
+		//     which will be retrieveable via Marshal.GetLastWin32Error()
+		[DllImport("iphlpapi.dll", SetLastError = true)]
+		static extern int GetIpForwardTable(IntPtr pIpForwardTable, ref int pdwSize, bool bOrder);
+
+		// Hold relevant network interface attributes.
+		private class InterfaceInfo
+		{
+			public string IpAddr      { get; set; }
+			public string Description {	get; set; }
+			public int Metric         { get; set; }
+		}
+
+		// Hold the current network interface candidates, one for Wi-Fi and one
+		// for Ethernet.
+		static InterfaceInfo IfaceWifi = new InterfaceInfo();
+		static InterfaceInfo IfaceEthernet = new InterfaceInfo();
+
+		// Possible results from network interface assessment.
+		private enum CommTypeToExpect
+		{
+			None = 0,
+			WiFi = 1,
+			Ethernet = 2
+		}
+
 		public static void DoAndroidSync(Project project, Form parent)
 		{
 			if (!project.IsRealProject)
@@ -42,12 +102,33 @@ namespace HearThis.Communication
 				return;
 			}
 			var dlg = new AndroidSyncDialog();
-			var address = GetNetworkAddress(parent);
 
-			if (address == null)
+			// Examine the network interfaces and determine which will be used for network traffic.
+			// Candidates will get stored in the two results objects.
+			CommTypeToExpect ifcResult = GetInterfaceStackWillUse(parent);
+
+			if (ifcResult == CommTypeToExpect.None)
+			{
+				Debug.WriteLine("WM, AndroidSynchronization, local IP not found");
 				return;
+			}
 
-			dlg.SetOurIpAddress(address.ToString());
+			string address = "";
+
+			if (ifcResult == CommTypeToExpect.WiFi)
+			{
+				// Network stack will use WiFi.
+				address = IfaceWifi.IpAddr;
+				Debug.WriteLine("WM, AndroidSynchronization, local IP = {0} ({1})", IfaceWifi.IpAddr, IfaceWifi.Description);
+			}
+			else
+			{
+				// Network stack will use Ethernet.
+				address = IfaceEthernet.IpAddr;
+				Debug.WriteLine("WM, AndroidSynchronization, local IP = {0} ({1})", IfaceEthernet.IpAddr, IfaceEthernet.Description);
+			}
+
+			dlg.SetOurIpAddress(address);
 			dlg.ShowAndroidIpAddress(); // AFTER we set our IP address, which may be used to provide a default
 			dlg.GotSync += (o, args) =>
 			{
@@ -138,9 +219,25 @@ namespace HearThis.Communication
 			dlg.Show(parent);
 		}
 
-		private static IPAddress GetNetworkAddress(Form parent)
+		// Survey the network interfaces and determine which one, if any, the network stack
+		// will use for network traffic.
+		//   - During the assessment the current leading WiFi candidate will be held in
+		//     'IfaceWifi', and similarly the current best candidate for Ethernet will be
+		//     in 'IfaceEthernet'.
+		//   - After assessment inform calling code of the winner by returning an enum
+		//     indicating which of the candidate structs to draw from: WiFi, Ethernet,
+		//     or neither.
+		//
+		private static CommTypeToExpect GetInterfaceStackWillUse(Form parent)
 		{
-			// Retrieve all network interfaces
+			int currentIfaceMetric;
+
+			// Initialize result structs metric field to the highest possible value
+			// so the first interface metric value seen will always replace it.
+			IfaceWifi.Metric = int.MaxValue;
+			IfaceEthernet.Metric = int.MaxValue;
+
+			// Retrieve all network interfaces that are *active*.
 			var allOperationalNetworks = NetworkInterface.GetAllNetworkInterfaces()
 				.Where(ni => ni.OperationalStatus == OperationalStatus.Up).ToArray();
 
@@ -149,42 +246,176 @@ namespace HearThis.Communication
 				MessageBox.Show(parent, LocalizationManager.GetString("AndroidSynchronization.NetworkingRequired",
 					"Android synchronization requires your computer to have networking enabled."),
 					Program.kProduct);
-				return null;
+				Debug.WriteLine("WM, AndroidSynchronization, no network interfaces are operational");
+				return CommTypeToExpect.None;
 			}
 
-			(NetworkInterface Network, IPAddress Address)? preferred = null;
-
-			foreach (var network in allOperationalNetworks)
+			// Get key attributes of active network interfaces.
+			foreach (NetworkInterface ni in allOperationalNetworks)
 			{
-				var ipAddress = network.GetIPProperties().UnicastAddresses.Select(ip => ip.Address)
-					.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork);
-
-				if (ipAddress != null)
+				// If we can't get IP or IPv4 properties for this interface, skip it.
+				var ipProps = ni.GetIPProperties();
+				if (ipProps == null)
 				{
-					if (network.NetworkInterfaceType == NetworkInterfaceType.Wireless80211)
-					{
-						preferred = (network, ipAddress);
-						break;
-					}
+					continue;
+				}
+				var ipv4Props = ipProps.GetIPv4Properties();
+				if (ipv4Props == null)
+				{
+					continue;
+				}
 
-					if (preferred == null)
-						preferred = (network, ipAddress);
+				Debug.WriteLine("WM, AndroidSynchronization, checking IP addresses in " + ni.Name);  // TEMPORARY
+				foreach (UnicastIPAddressInformation ip in ipProps.UnicastAddresses)
+				{
+					// We don't consider IPv6 so filter for IPv4 ('InterNetwork')...
+					if (ip.Address.AddressFamily == AddressFamily.InterNetwork)
+					{
+						// ...And of these we care only about WiFi and Ethernet.
+						if (ni.NetworkInterfaceType == NetworkInterfaceType.Wireless80211)
+						{
+							Debug.WriteLine("  WiFi...");  // TEMPORARY
+							currentIfaceMetric = GetMetricForInterface(ipv4Props.Index);
+
+							// Save this interface if its metric is lowest we've seen so far.
+							if (currentIfaceMetric < IfaceWifi.Metric)
+							{
+								Debug.WriteLine("  updating WiFi metric to " + currentIfaceMetric);  // TEMPORARY
+								IfaceWifi.IpAddr = ip.Address.ToString();
+								IfaceWifi.Description = ni.Description;
+								IfaceWifi.Metric = currentIfaceMetric;
+							}
+						}
+						else if (ni.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
+						{
+							Debug.WriteLine("  Ethernet...");  // TEMPORARY
+							currentIfaceMetric = GetMetricForInterface(ipv4Props.Index);
+
+							// Save this interface if its metric is lowest we've seen so far.
+							if (currentIfaceMetric < IfaceEthernet.Metric)
+							{
+								Debug.WriteLine("  updating Ethernet metric to " + currentIfaceMetric);  // TEMPORARY
+								IfaceEthernet.IpAddr = ip.Address.ToString();
+								IfaceEthernet.Description = ni.Description;
+								IfaceEthernet.Metric = currentIfaceMetric;
+							}
+						}
+					}
 				}
 			}
 
-			if (!preferred.HasValue)
+			// Active network interfaces have all been assessed.
+			//   - The WiFi interface having the lowest metric has been saved in the
+			//     WiFi result struct. Note: if no active WiFi interface was seen then
+			//     the result struct's metric field will still have its initial value.
+			//   - Likewise for Ethernet.
+			// Now choose the winner, if there is one:
+			//   - If we saw an active WiFi interface, return that
+			//   - Else if we saw an active Ethernet interface, return that
+			//   - Else there is no winner so return none
+			if (IfaceWifi.Metric < int.MaxValue)
 			{
-				MessageBox.Show(parent, LocalizationManager.GetString("AndroidSynchronization.NoInterNetworkIPAddress",
-					"Sorry, your network adapter has no InterNetwork IP address. If you do not know how to resolve this, please seek technical help.",
-					Program.kProduct));
-				return null;
+				Debug.WriteLine("WM, WiFi wins, interface = " + IfaceWifi.Description);  // TEMPORARY
+				Logger.WriteEvent("Found " +
+				$"a network for Android synchronization: " + IfaceWifi.Description);
+				return CommTypeToExpect.WiFi;
+			}
+			if (IfaceEthernet.Metric < int.MaxValue)
+			{
+				Debug.WriteLine("WM, Ethernet wins, interface = " + IfaceEthernet.Description);  // TEMPORARY
+				Logger.WriteEvent("Found " +
+				$"a network for Android synchronization: " + IfaceEthernet.Description);
+				return CommTypeToExpect.Ethernet;
 			}
 
-			Logger.WriteEvent("Found " +
-				$"{(preferred.Value.Network.NetworkInterfaceType == NetworkInterfaceType.Wireless80211 ? "a" : "only a wired")}" +
-				$" network for Android synchronization: {preferred.Value.Network.Description}.");
-			
-			return preferred.Value.Address;
+			MessageBox.Show(parent, LocalizationManager.GetString("AndroidSynchronization.NoInterNetworkIPAddress",
+				"Sorry, your network adapter has no InterNetwork IP address. If you do not know how to resolve this, please seek technical help.",
+				Program.kProduct));
+			return CommTypeToExpect.None;
+		}
+
+		// Get a key piece of info ("metric") from the specified network interface.
+		// https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getipforwardtable
+		//
+		// Retrieving the metric is not as simple as grabbing one of the fields in
+		// the network interface. The metric resides in the network stack routing
+		// table. One of the interface fields ("Index") is also in the routing table
+		// and is how we correlate the two.
+		//   - Calling code (walking the interface collection) passes in the index
+		//     of the interface whose "best" metric it wants.
+		//   - This function walks the routing table looking for all rows (each of
+		//     which is a route) containing that index. It notes the metric in each
+		//     route and returns the lowest among all routes/rows for the interface.
+		//
+		private static int GetMetricForInterface(int interfaceIndex)
+		{
+			// Initialize to "worst" possible metric (Win10 Pro: 2^31 - 1).
+			// It can only get better from there!
+			int bestMetric = int.MaxValue;
+
+			// Preliminary: call with a null buffer ('size') to learn how large a
+			// buffer is needed to hold a copy of the routing table.
+			int size = 0;
+			GetIpForwardTable(IntPtr.Zero, ref size, false);
+
+			IntPtr tableBuf;
+
+			try
+			{
+				// 'size' now shows how large a buffer is needed, so allocate it.
+				tableBuf = Marshal.AllocHGlobal(size);
+			}
+			catch (OutOfMemoryException e)
+			{
+				Debug.WriteLine("  GetMetricForInterface, ERROR creating buffer: " + e);
+				return bestMetric;
+			}
+
+			try
+			{
+				// Copy the routing table into buffer for examination.
+				int error = GetIpForwardTable(tableBuf, ref size, false);
+				if (error != 0)
+				{
+					// Something went wrong so bail.
+					// It is tempting to add a dealloc call here, but don't. The
+					// dealloc in the 'finally' block *will* be done (I checked).
+					Console.WriteLine("  GetMetricForInterface, ERROR, GetIpForwardTable() = {0}, returning {1}", error, bestMetric);
+					return bestMetric;
+				}
+
+				// Get number of routing table entries.
+				int numEntries = Marshal.ReadInt32(tableBuf);
+
+				// Advance pointer past the integer to point at 1st row.
+				IntPtr rowPtr = IntPtr.Add(tableBuf, 4);
+
+				// Walk the routing table looking for rows involving the the network
+				// interface passed in. For each such row/route, check the metric.
+				// If it is lower than the lowest we've yet seen, save it to become
+				// the new benchmark.
+				for (int i = 0; i < numEntries; i++)
+				{
+					MIB_IPFORWARDROW row = Marshal.PtrToStructure<MIB_IPFORWARDROW>(rowPtr);
+					if (row.dwForwardIfIndex == interfaceIndex)
+					{
+						bestMetric = Math.Min(bestMetric, row.dwForwardMetric1);
+					}
+					rowPtr = IntPtr.Add(rowPtr, Marshal.SizeOf<MIB_IPFORWARDROW>());
+				}
+			}
+			catch (Exception e)
+			{
+				if (e is AccessViolationException || e is MissingMethodException)
+				{
+					Debug.WriteLine("  GetMetricForInterface, ERROR: " + e);
+				}
+			}
+			finally
+			{
+				Marshal.FreeHGlobal(tableBuf);
+			}
+			return bestMetric;
 		}
 	}
 }

--- a/src/HearThis/Communication/AndroidSynchronization.cs
+++ b/src/HearThis/Communication/AndroidSynchronization.cs
@@ -109,7 +109,7 @@ namespace HearThis.Communication
 
 			if (ifcResult == CommTypeToExpect.None)
 			{
-				Debug.WriteLine("WM, AndroidSynchronization, local IP not found");
+				Debug.WriteLine("AndroidSynchronization, local IP not found");
 				return;
 			}
 
@@ -119,13 +119,13 @@ namespace HearThis.Communication
 			{
 				// Network stack will use WiFi.
 				address = IfaceWifi.IpAddr;
-				Debug.WriteLine("WM, AndroidSynchronization, local IP = {0} ({1})", IfaceWifi.IpAddr, IfaceWifi.Description);
+				Debug.WriteLine("AndroidSynchronization, using Wi-Fi, local IP = {0} ({1})", IfaceWifi.IpAddr, IfaceWifi.Description);
 			}
 			else
 			{
 				// Network stack will use Ethernet.
 				address = IfaceEthernet.IpAddr;
-				Debug.WriteLine("WM, AndroidSynchronization, local IP = {0} ({1})", IfaceEthernet.IpAddr, IfaceEthernet.Description);
+				Debug.WriteLine("AndroidSynchronization, using Ethernet, local IP = {0} ({1})", IfaceEthernet.IpAddr, IfaceEthernet.Description);
 			}
 
 			dlg.SetOurIpAddress(address);
@@ -246,7 +246,6 @@ namespace HearThis.Communication
 				MessageBox.Show(parent, LocalizationManager.GetString("AndroidSynchronization.NetworkingRequired",
 					"Android synchronization requires your computer to have networking enabled."),
 					Program.kProduct);
-				Debug.WriteLine("WM, AndroidSynchronization, no network interfaces are operational");
 				return CommTypeToExpect.None;
 			}
 
@@ -265,7 +264,6 @@ namespace HearThis.Communication
 					continue;
 				}
 
-				Debug.WriteLine("WM, AndroidSynchronization, checking IP addresses in " + ni.Name);  // TEMPORARY
 				foreach (UnicastIPAddressInformation ip in ipProps.UnicastAddresses)
 				{
 					// We don't consider IPv6 so filter for IPv4 ('InterNetwork')...
@@ -274,13 +272,11 @@ namespace HearThis.Communication
 						// ...And of these we care only about WiFi and Ethernet.
 						if (ni.NetworkInterfaceType == NetworkInterfaceType.Wireless80211)
 						{
-							Debug.WriteLine("  WiFi...");  // TEMPORARY
 							currentIfaceMetric = GetMetricForInterface(ipv4Props.Index);
 
 							// Save this interface if its metric is lowest we've seen so far.
 							if (currentIfaceMetric < IfaceWifi.Metric)
 							{
-								Debug.WriteLine("  updating WiFi metric to " + currentIfaceMetric);  // TEMPORARY
 								IfaceWifi.IpAddr = ip.Address.ToString();
 								IfaceWifi.Description = ni.Description;
 								IfaceWifi.Metric = currentIfaceMetric;
@@ -288,13 +284,11 @@ namespace HearThis.Communication
 						}
 						else if (ni.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
 						{
-							Debug.WriteLine("  Ethernet...");  // TEMPORARY
 							currentIfaceMetric = GetMetricForInterface(ipv4Props.Index);
 
 							// Save this interface if its metric is lowest we've seen so far.
 							if (currentIfaceMetric < IfaceEthernet.Metric)
 							{
-								Debug.WriteLine("  updating Ethernet metric to " + currentIfaceMetric);  // TEMPORARY
 								IfaceEthernet.IpAddr = ip.Address.ToString();
 								IfaceEthernet.Description = ni.Description;
 								IfaceEthernet.Metric = currentIfaceMetric;
@@ -315,14 +309,12 @@ namespace HearThis.Communication
 			//   - Else there is no winner so return none
 			if (IfaceWifi.Metric < int.MaxValue)
 			{
-				Debug.WriteLine("WM, WiFi wins, interface = " + IfaceWifi.Description);  // TEMPORARY
 				Logger.WriteEvent("Found " +
 				$"a network for Android synchronization: " + IfaceWifi.Description);
 				return CommTypeToExpect.WiFi;
 			}
 			if (IfaceEthernet.Metric < int.MaxValue)
 			{
-				Debug.WriteLine("WM, Ethernet wins, interface = " + IfaceEthernet.Description);  // TEMPORARY
 				Logger.WriteEvent("Found " +
 				$"a network for Android synchronization: " + IfaceEthernet.Description);
 				return CommTypeToExpect.Ethernet;
@@ -380,7 +372,7 @@ namespace HearThis.Communication
 					// Something went wrong so bail.
 					// It is tempting to add a dealloc call here, but don't. The
 					// dealloc in the 'finally' block *will* be done (I checked).
-					Console.WriteLine("  GetMetricForInterface, ERROR, GetIpForwardTable() = {0}, returning {1}", error, bestMetric);
+					Console.WriteLine("  GetMetricForInterface, ERROR getting table: " + error);
 					return bestMetric;
 				}
 
@@ -408,7 +400,7 @@ namespace HearThis.Communication
 			{
 				if (e is AccessViolationException || e is MissingMethodException)
 				{
-					Debug.WriteLine("  GetMetricForInterface, ERROR: " + e);
+					Debug.WriteLine("  GetMetricForInterface, ERROR, exception = " + e);
 				}
 			}
 			finally

--- a/src/HearThis/Communication/AndroidSynchronization.cs
+++ b/src/HearThis/Communication/AndroidSynchronization.cs
@@ -131,7 +131,7 @@ namespace HearThis.Communication
 					int result = GetIpForwardTable(IntPtr.Zero, ref size, true);
 					if (result != ERROR_INSUFFICIENT_BUFFER)
 					{
-						Debug.WriteLine($"SYNC_LRT, error ({result}) getting size");
+						Debug.WriteLine($"AndroidSynchronization, error ({result}) getting size");
 						throw new Win32Exception(result);
 					}
 					Debug.WriteLine($"SYNC_LRT, got size = {size}"); // TEMPORARY
@@ -143,7 +143,7 @@ namespace HearThis.Communication
 					result = GetIpForwardTable(RoutingTableBuf, ref size, true);
 					if (result != 0)
 					{
-						Debug.WriteLine($"SYNC_LRT, error ({result}) getting buffer or table");
+						Debug.WriteLine($"AndroidSynchronization, error ({result}) getting buffer or table");
 						throw new Win32Exception(result);
 					}
 
@@ -184,7 +184,7 @@ namespace HearThis.Communication
 				}
 				catch (Exception e)
 				{
-					Debug.WriteLine($"SYNC_LRT, got exception ({e})");
+					Debug.WriteLine($"AndroidSynchronization, got exception ({e})");
 				}
 				finally
 				{
@@ -230,11 +230,8 @@ namespace HearThis.Communication
 
 			if (localIp == "")
 			{
-				Debug.WriteLine("AndroidSynchronization, local IP not found");
 				return;
 			}
-
-			Debug.WriteLine("AndroidSynchronization, got local IP = " + localIp); // TEMPORARY
 
 			var dlg = new AndroidSyncDialog();
 
@@ -429,19 +426,20 @@ namespace HearThis.Communication
 			if (wifiInterface.Metric < int.MaxValue)
 			{
 				Logger.WriteEvent($"Found a network for Android synchronization: {wifiInterface.Description}");
-				Debug.WriteLine($"GISWU, using Wi-Fi, local IP = {wifiInterface.IpAddr} ({wifiInterface.Description})"); // TEMPORARY
+				Debug.WriteLine($"AndroidSynchronization using Wi-Fi, local IP = {wifiInterface.IpAddr} ({wifiInterface.Description})");
 				return wifiInterface.IpAddr;
 			}
 			if (ethernetInterface.Metric < int.MaxValue)
 			{
 				Logger.WriteEvent($"Found a network for Android synchronization: {ethernetInterface.Description}");
-				Debug.WriteLine($"GISWU, using Ethernet, local IP = {ethernetInterface.IpAddr} ({ethernetInterface.Description})"); // TEMPORARY
+				Debug.WriteLine($"AndroidSynchronization using Ethernet, local IP = {ethernetInterface.IpAddr} ({ethernetInterface.Description})");
 				return ethernetInterface.IpAddr;
 			}
 
 			MessageBox.Show(parent, LocalizationManager.GetString("AndroidSynchronization.NoInterNetworkIPAddress",
 				"Sorry, your network adapter has no InterNetwork IP address. If you do not know how to resolve this, please seek technical help.",
 				Program.kProduct));
+			Debug.WriteLine("AndroidSynchronization, local IP address not found");
 			return "";
 		}
 	}


### PR DESCRIPTION
When advertising its local IP address in a QR code, HearThis (HT) can sometimes show the wrong address. This is because it decides to use the wrong network interface. I observed this in my home setup three months ago. Windows 10 chose to use a virtual interface associated with my machine's VPN tunnel, and the tunnel's IP address got baked into the QR code for HearThisAndroid (HTA) to scan. This local IP address lived on a different subnet, which HTA's UDP response could not reach. Thus the desired HT/HTA connection and sync never occurred.

This changeset addresses the issue by determining the local IP in very similar fashion to a PR submitted yesterday for BloomDesktop. The sequence goes like this:
A) Examine the machine's network interfaces. Note that there could be several of these - my Win10 laptop has 11. Focus on the *active* Wi-Fi and Ethernet network interfaces and record their "interface metric" values.
B) Determine which interface the network stack will use for network traffic. Literature says the stack wants to use the interface with the lowest metric value. We want to prefer Wi-Fi over Ethernet. I have not seen a case where these criteria conflict, so the "winning" interface is selected thus:
    - IF a Wi-Fi interface is active, choose that
    - ELSE IF an Ethernet interface is active, choose that
    - ELSE declare 'none' and no local IP address will be declared
An interface is considered active if its interface metric is less than the initialized value of (2^31 - 1). On my machine at least, inactive interfaces all do maintain this initial value.
C) Note the winning interface's IP address. This is declared the Local IP address, to be put into the QR code.

Possible future improvement (unrelated to this PR's issue): modify the response from HTA to use TCP instead of UDP. If this were to be done, HT/HTA devices in separate subnets would at least have a fighting chance to connect. Routers are often configured to pass TCP traffic between subnets, but they pass UDP traffic much less often.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/hearthis/329)
<!-- Reviewable:end -->
